### PR TITLE
Removal of master/slave lingo

### DIFF
--- a/devstack/doc/source/conf.py
+++ b/devstack/doc/source/conf.py
@@ -39,8 +39,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'DevStack'

--- a/horizon/doc/source/conf.py
+++ b/horizon/doc/source/conf.py
@@ -182,8 +182,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Horizon'

--- a/horizon/openstack_dashboard/management/commands/make_web_conf.py
+++ b/horizon/openstack_dashboard/management/commands/make_web_conf.py
@@ -84,7 +84,7 @@ if len(VHOSTNAME) > 1:
     context['DOMAINNAME'] = '.'.join(VHOSTNAME[1:])
 else:
     context['DOMAINNAME'] = 'openstack.org'
-context['ADMIN'] = 'webmaster@%s' % context['DOMAINNAME']
+context['ADMIN'] = 'webmain@%s' % context['DOMAINNAME']
 
 context['ACTIVATE_THIS'] = None
 virtualenv = os.environ.get('VIRTUAL_ENV')

--- a/horizon/openstack_dashboard/test/test_data/sahara_data.py
+++ b/horizon/openstack_dashboard/test/test_data/sahara_data.py
@@ -151,7 +151,7 @@ def data(TEST):
                 "flavor_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                 "floating_ip_pool": None,
                 "image_id": None,
-                "name": "master",
+                "name": "main",
                 "node_configs": {},
                 "node_group_template_id": "c166dfcc-9cc7-4b48-adc9",
                 "node_processes": [
@@ -221,14 +221,14 @@ def data(TEST):
                         "created_at": "2014-06-04 20:02:14.834529",
                         "id": "c3b8004b-7063-4b99-a082-820cdc6e961c",
                         "instance_id": "a45f5495-4a10-4f17-8fae",
-                        "instance_name": "cercluster-master-001",
+                        "instance_name": "cercluster-main-001",
                         "internal_ip": None,
                         "management_ip": None,
                         "updated_at": None,
                         "volumes": []
                     }
                 ],
-                "name": "master",
+                "name": "main",
                 "node_configs": {},
                 "node_group_template_id": "c166dfcc-9cc7-4b48-adc9",
                 "node_processes": [
@@ -439,7 +439,7 @@ def data(TEST):
                     "stats": None,
                     "status": "RUNNING",
                     "toString": "Action name[job-node] status[RUNNING]",
-                    "trackerUri": "cercluster-master-001:8021",
+                    "trackerUri": "cercluster-main-001:8021",
                     "transition": None,
                     "type": "pig"
                 }

--- a/nova/doc/source/conf.py
+++ b/nova/doc/source/conf.py
@@ -54,8 +54,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'nova'

--- a/nova/nova/api/openstack/wsgi.py
+++ b/nova/nova/api/openstack/wsgi.py
@@ -429,7 +429,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/nova/nova/compute/manager.py
+++ b/nova/nova/compute/manager.py
@@ -694,7 +694,7 @@ class ComputeManager(manager.Manager):
                 return objects.InstanceList()
             filters['uuid'] = driver_uuids
             local_instances = objects.InstanceList.get_by_filters(
-                context, filters, use_slave=True)
+                context, filters, use_subordinate=True)
             return local_instances
         except NotImplementedError:
             pass
@@ -703,7 +703,7 @@ class ComputeManager(manager.Manager):
         # to brute force.
         driver_instances = self.driver.list_instances()
         instances = objects.InstanceList.get_by_filters(context, filters,
-                                                        use_slave=True)
+                                                        use_subordinate=True)
         name_map = {instance.name: instance for instance in instances}
         local_instances = []
         for driver_instance in driver_instances:
@@ -1243,7 +1243,7 @@ class ComputeManager(manager.Manager):
         """This call passes straight through to the virtualization driver."""
         return self.driver.refresh_provider_fw_rules()
 
-    def _get_instance_nw_info(self, context, instance, use_slave=False):
+    def _get_instance_nw_info(self, context, instance, use_subordinate=False):
         """Get a list of dictionaries of network data of an instance."""
         if (not hasattr(instance, 'system_metadata') or
                 len(instance['system_metadata']) == 0):
@@ -1256,7 +1256,7 @@ class ComputeManager(manager.Manager):
             instance = objects.Instance.get_by_uuid(context,
                                                     instance['uuid'],
                                                     expected_attrs=attrs,
-                                                    use_slave=use_slave)
+                                                    use_subordinate=use_subordinate)
 
         network_info = self.network_api.get_instance_nw_info(context,
                                                              instance)
@@ -1628,7 +1628,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
 
         building_insts = objects.InstanceList.get_by_filters(context,
-                           filters, expected_attrs=[], use_slave=True)
+                           filters, expected_attrs=[], use_subordinate=True)
 
         for instance in building_insts:
             if timeutils.is_older_than(instance['created_at'], timeout):
@@ -5365,7 +5365,7 @@ class ComputeManager(manager.Manager):
             # The list of instances to heal is empty so rebuild it
             LOG.debug('Rebuilding the list of instances to heal')
             db_instances = objects.InstanceList.get_by_host(
-                context, self.host, expected_attrs=[], use_slave=True)
+                context, self.host, expected_attrs=[], use_subordinate=True)
             for inst in db_instances:
                 # We don't want to refresh the cache for instances
                 # which are building or deleting so don't put them
@@ -5395,7 +5395,7 @@ class ComputeManager(manager.Manager):
                     inst = objects.Instance.get_by_uuid(
                             context, instance_uuids.pop(0),
                             expected_attrs=['system_metadata', 'info_cache'],
-                            use_slave=True)
+                            use_subordinate=True)
                 except exception.InstanceNotFound:
                     # Instance is gone.  Try to grab another.
                     continue
@@ -5418,7 +5418,7 @@ class ComputeManager(manager.Manager):
             try:
                 # Call to network API to get instance info.. this will
                 # force an update to the instance's info_cache
-                self._get_instance_nw_info(context, instance, use_slave=True)
+                self._get_instance_nw_info(context, instance, use_subordinate=True)
                 LOG.debug('Updated the network info_cache for instance',
                           instance=instance)
             except exception.InstanceNotFound:
@@ -5439,7 +5439,7 @@ class ComputeManager(manager.Manager):
             filters = {'task_state': task_states.REBOOTING,
                        'host': self.host}
             rebooting = objects.InstanceList.get_by_filters(
-                context, filters, expected_attrs=[], use_slave=True)
+                context, filters, expected_attrs=[], use_subordinate=True)
 
             to_poll = []
             for instance in rebooting:
@@ -5456,7 +5456,7 @@ class ComputeManager(manager.Manager):
                        'host': self.host}
             rescued_instances = objects.InstanceList.get_by_filters(
                 context, filters, expected_attrs=["system_metadata"],
-                use_slave=True)
+                use_subordinate=True)
 
             to_unrescue = []
             for instance in rescued_instances:
@@ -5474,7 +5474,7 @@ class ComputeManager(manager.Manager):
 
         migrations = objects.MigrationList.get_unconfirmed_by_dest_compute(
                 context, CONF.resize_confirm_window, self.host,
-                use_slave=True)
+                use_subordinate=True)
 
         migrations_info = dict(migration_count=len(migrations),
                 confirm_window=CONF.resize_confirm_window)
@@ -5503,7 +5503,7 @@ class ComputeManager(manager.Manager):
             try:
                 instance = objects.Instance.get_by_uuid(context,
                             instance_uuid, expected_attrs=expected_attrs,
-                            use_slave=True)
+                            use_subordinate=True)
             except exception.InstanceNotFound:
                 reason = (_("Instance %s not found") %
                           instance_uuid)
@@ -5560,7 +5560,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
         shelved_instances = objects.InstanceList.get_by_filters(
             context, filters=filters, expected_attrs=['system_metadata'],
-            use_slave=True)
+            use_subordinate=True)
 
         to_gc = []
         for instance in shelved_instances:
@@ -5593,7 +5593,7 @@ class ComputeManager(manager.Manager):
         instances = objects.InstanceList.get_active_by_window_joined(
             context, begin, end, host=self.host,
             expected_attrs=['system_metadata', 'info_cache', 'metadata'],
-            use_slave=True)
+            use_subordinate=True)
         num_instances = len(instances)
         errors = 0
         successes = 0
@@ -5657,7 +5657,7 @@ class ComputeManager(manager.Manager):
 
             instances = objects.InstanceList.get_by_host(context,
                                                               self.host,
-                                                              use_slave=True)
+                                                              use_subordinate=True)
             try:
                 bw_counters = self.driver.get_all_bw_counters(instances)
             except NotImplementedError:
@@ -5682,7 +5682,7 @@ class ComputeManager(manager.Manager):
                 last_ctr_out = None
                 usage = objects.BandwidthUsage.get_by_instance_uuid_and_mac(
                     context, bw_ctr['uuid'], bw_ctr['mac_address'],
-                    start_period=start_time, use_slave=True)
+                    start_period=start_time, use_subordinate=True)
                 if usage:
                     bw_in = usage.bw_in
                     bw_out = usage.bw_out
@@ -5692,7 +5692,7 @@ class ComputeManager(manager.Manager):
                     usage = (objects.BandwidthUsage.
                              get_by_instance_uuid_and_mac(
                         context, bw_ctr['uuid'], bw_ctr['mac_address'],
-                        start_period=prev_time, use_slave=True))
+                        start_period=prev_time, use_subordinate=True))
                     if usage:
                         last_ctr_in = usage.last_ctr_in
                         last_ctr_out = usage.last_ctr_out
@@ -5722,14 +5722,14 @@ class ComputeManager(manager.Manager):
                                               last_refreshed=refreshed,
                                               update_cells=update_cells)
 
-    def _get_host_volume_bdms(self, context, use_slave=False):
+    def _get_host_volume_bdms(self, context, use_subordinate=False):
         """Return all block device mappings on a compute host."""
         compute_host_bdms = []
         instances = objects.InstanceList.get_by_host(context, self.host,
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         for instance in instances:
             bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
-                    context, instance.uuid, use_slave=use_slave)
+                    context, instance.uuid, use_subordinate=use_subordinate)
             instance_bdms = [bdm for bdm in bdms if bdm.is_volume]
             compute_host_bdms.append(dict(instance=instance,
                                           instance_bdms=instance_bdms))
@@ -5757,7 +5757,7 @@ class ComputeManager(manager.Manager):
             start_time = utils.last_completed_audit_period()[1]
 
         compute_host_bdms = self._get_host_volume_bdms(context,
-                                                       use_slave=True)
+                                                       use_subordinate=True)
         if not compute_host_bdms:
             return
 
@@ -5783,7 +5783,7 @@ class ComputeManager(manager.Manager):
         """
         db_instances = objects.InstanceList.get_by_host(context, self.host,
                                                         expected_attrs=[],
-                                                        use_slave=True)
+                                                        use_subordinate=True)
 
         num_vm_instances = self.driver.get_num_instances()
         num_db_instances = len(db_instances)
@@ -5842,14 +5842,14 @@ class ComputeManager(manager.Manager):
             self._sync_instance_power_state(context,
                                             db_instance,
                                             vm_power_state,
-                                            use_slave=True)
+                                            use_subordinate=True)
         except exception.InstanceNotFound:
             # NOTE(hanlind): If the instance gets deleted during sync,
             # silently ignore.
             pass
 
     def _sync_instance_power_state(self, context, db_instance, vm_power_state,
-                                   use_slave=False):
+                                   use_subordinate=False):
         """Align instance power state between the database and hypervisor.
 
         If the instance is not found on the hypervisor, but is in the database,
@@ -5858,7 +5858,7 @@ class ComputeManager(manager.Manager):
 
         # We re-query the DB to get the latest instance info to minimize
         # (not eliminate) race condition.
-        db_instance.refresh(use_slave=use_slave)
+        db_instance.refresh(use_subordinate=use_subordinate)
         db_power_state = db_instance.power_state
         vm_state = db_instance.vm_state
 
@@ -6024,7 +6024,7 @@ class ComputeManager(manager.Manager):
         instances = objects.InstanceList.get_by_filters(
             context, filters,
             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True)
+            use_subordinate=True)
         for instance in instances:
             if self._deleted_old_enough(instance, interval):
                 bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
@@ -6055,7 +6055,7 @@ class ComputeManager(manager.Manager):
 
         # Delete orphan compute node not reported by driver but still in db
         compute_nodes_in_db = self._get_compute_nodes_in_db(context,
-                                                            use_slave=True)
+                                                            use_subordinate=True)
 
         for cn in compute_nodes_in_db:
             if cn.hypervisor_hostname not in nodenames:
@@ -6064,10 +6064,10 @@ class ComputeManager(manager.Manager):
 
         self._resource_tracker_dict = new_resource_tracker_dict
 
-    def _get_compute_nodes_in_db(self, context, use_slave=False):
+    def _get_compute_nodes_in_db(self, context, use_subordinate=False):
         try:
             return objects.ComputeNodeList.get_all_by_host(context, self.host,
-                                                           use_slave=use_slave)
+                                                           use_subordinate=use_subordinate)
         except exception.NotFound:
             LOG.error(_LE("No compute node record for host %s"), self.host)
             return []
@@ -6134,7 +6134,7 @@ class ComputeManager(manager.Manager):
                                  "DELETED but still present on host."),
                              instance['name'], instance=instance)
                     bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
-                        context, instance.uuid, use_slave=True)
+                        context, instance.uuid, use_subordinate=True)
                     self.instance_events.clear_events_for_instance(instance)
                     try:
                         self._shutdown_instance(context, instance, bdms,
@@ -6203,11 +6203,11 @@ class ComputeManager(manager.Manager):
 
     @aggregate_object_compat
     @wrap_exception()
-    def add_aggregate_host(self, context, aggregate, host, slave_info):
+    def add_aggregate_host(self, context, aggregate, host, subordinate_info):
         """Notify hypervisor of change (for hypervisor pools)."""
         try:
             self.driver.add_to_aggregate(context, aggregate, host,
-                                         slave_info=slave_info)
+                                         subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'add_aggregate_host')
@@ -6220,11 +6220,11 @@ class ComputeManager(manager.Manager):
 
     @aggregate_object_compat
     @wrap_exception()
-    def remove_aggregate_host(self, context, host, slave_info, aggregate):
+    def remove_aggregate_host(self, context, host, subordinate_info, aggregate):
         """Removes a host from a physical hypervisor pool."""
         try:
             self.driver.remove_from_aggregate(context, aggregate, host,
-                                              slave_info=slave_info)
+                                              subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'remove_aggregate_host')
@@ -6282,7 +6282,7 @@ class ComputeManager(manager.Manager):
                    'soft_deleted': True,
                    'host': nodes}
         filtered_instances = objects.InstanceList.get_by_filters(context,
-                                 filters, expected_attrs=[], use_slave=True)
+                                 filters, expected_attrs=[], use_subordinate=True)
 
         self.driver.manage_image_cache(context, filtered_instances)
 
@@ -6297,7 +6297,7 @@ class ComputeManager(manager.Manager):
         attrs = ['info_cache', 'security_groups', 'system_metadata']
         with utils.temporary_mutation(context, read_deleted='yes'):
             instances = objects.InstanceList.get_by_filters(
-                context, filters, expected_attrs=attrs, use_slave=True)
+                context, filters, expected_attrs=attrs, use_subordinate=True)
         LOG.debug('There are %d instances to clean', len(instances))
 
         for instance in instances:

--- a/nova/nova/compute/rpcapi.py
+++ b/nova/nova/compute/rpcapi.py
@@ -151,7 +151,7 @@ class ComputeAPI(object):
 
         * 2.0 - Remove 1.x backwards compat
         * 2.1 - Adds orig_sys_metadata to rebuild_instance()
-        * 2.2 - Adds slave_info parameter to add_aggregate_host() and
+        * 2.2 - Adds subordinate_info parameter to add_aggregate_host() and
                 remove_aggregate_host()
         * 2.3 - Adds volume_id to reserve_block_device_name()
         * 2.4 - Add bdms to terminate_instance
@@ -304,7 +304,7 @@ class ComputeAPI(object):
                               serializer=serializer)
 
     def add_aggregate_host(self, ctxt, aggregate, host_param, host,
-                           slave_info=None):
+                           subordinate_info=None):
         '''Add aggregate host.
 
         :param ctxt: request context
@@ -317,7 +317,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'add_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def add_fixed_ip_to_instance(self, ctxt, instance, network_id):
         version = '3.12'
@@ -644,7 +644,7 @@ class ComputeAPI(object):
         cctxt.cast(ctxt, 'refresh_provider_fw_rules')
 
     def remove_aggregate_host(self, ctxt, aggregate, host_param, host,
-                              slave_info=None):
+                              subordinate_info=None):
         '''Remove aggregate host.
 
         :param ctxt: request context
@@ -657,7 +657,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'remove_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def remove_fixed_ip_from_instance(self, ctxt, instance, address):
         version = '3.13'

--- a/nova/nova/conductor/manager.py
+++ b/nova/nova/conductor/manager.py
@@ -224,10 +224,10 @@ class ConductorManager(manager.Manager):
 
     def instance_get_all_by_filters(self, context, filters, sort_key,
                                     sort_dir, columns_to_join,
-                                    use_slave):
+                                    use_subordinate):
         result = self.db.instance_get_all_by_filters(
             context, filters, sort_key, sort_dir,
-            columns_to_join=columns_to_join, use_slave=use_slave)
+            columns_to_join=columns_to_join, use_subordinate=use_subordinate)
         return jsonutils.to_primitive(result)
 
     def instance_get_active_by_window(self, context, begin, end,

--- a/nova/nova/conductor/rpcapi.py
+++ b/nova/nova/conductor/rpcapi.py
@@ -124,7 +124,7 @@ class ConductorAPI(object):
     * 1.62 - Added object_backport()
     * 1.63 - Changed the format of values['stats'] from a dict to a JSON string
              in compute_node_update()
-    * 1.64 - Added use_slave to instance_get_all_filters()
+    * 1.64 - Added use_subordinate to instance_get_all_filters()
            - Remove instance_type_get()
            - Remove aggregate_get()
            - Remove aggregate_get_by_host()

--- a/nova/nova/console/xvp.py
+++ b/nova/nova/console/xvp.py
@@ -40,7 +40,7 @@ xvp_opts = [
                help='Generated XVP conf file'),
     cfg.StrOpt('console_xvp_pid',
                default='/var/run/xvp.pid',
-               help='XVP master process pid file'),
+               help='XVP main process pid file'),
     cfg.StrOpt('console_xvp_log',
                default='/var/log/xvp.log',
                help='XVP log file'),

--- a/nova/nova/db/api.py
+++ b/nova/nova/db/api.py
@@ -95,11 +95,11 @@ def service_destroy(context, service_id):
 
 
 def service_get(context, service_id, with_compute_node=False,
-                use_slave=False):
+                use_subordinate=False):
     """Get a service or raise if it does not exist."""
     return IMPL.service_get(context, service_id,
                             with_compute_node=with_compute_node,
-                            use_slave=use_slave)
+                            use_subordinate=use_subordinate)
 
 
 def service_get_by_host_and_topic(context, host, topic):
@@ -122,13 +122,13 @@ def service_get_all_by_host(context, host):
     return IMPL.service_get_all_by_host(context, host)
 
 
-def service_get_by_compute_host(context, host, use_slave=False):
+def service_get_by_compute_host(context, host, use_subordinate=False):
     """Get the service entry for a given compute host.
 
     Returns the service entry joined with the compute_node entry.
     """
     return IMPL.service_get_by_compute_host(context, host,
-                                            use_slave=use_slave)
+                                            use_subordinate=use_subordinate)
 
 
 def service_get_by_args(context, host, binary):
@@ -212,7 +212,7 @@ def compute_node_get_all(context, no_date_fields=False):
     return IMPL.compute_node_get_all(context, no_date_fields)
 
 
-def compute_node_get_all_by_host(context, host, use_slave=False):
+def compute_node_get_all_by_host(context, host, use_subordinate=False):
     """Get compute nodes by host name
 
     :param context: The security context (admin)
@@ -220,7 +220,7 @@ def compute_node_get_all_by_host(context, host, use_slave=False):
 
     :returns: List of dictionaries each containing compute node properties
     """
-    return IMPL.compute_node_get_all_by_host(context, host, use_slave)
+    return IMPL.compute_node_get_all_by_host(context, host, use_subordinate)
 
 
 def compute_node_search_by_hypervisor(context, hypervisor_match):
@@ -467,12 +467,12 @@ def migration_get_by_instance_and_status(context, instance_uuid, status):
 
 
 def migration_get_unconfirmed_by_dest_compute(context, confirm_window,
-        dest_compute, use_slave=False):
+        dest_compute, use_subordinate=False):
     """Finds all unconfirmed migrations within the confirmation window for
     a specific destination compute host.
     """
     return IMPL.migration_get_unconfirmed_by_dest_compute(context,
-            confirm_window, dest_compute, use_slave=use_slave)
+            confirm_window, dest_compute, use_subordinate=use_subordinate)
 
 
 def migration_get_in_progress_by_host_and_node(context, host, node):
@@ -604,10 +604,10 @@ def virtual_interface_get_by_uuid(context, vif_uuid):
     return IMPL.virtual_interface_get_by_uuid(context, vif_uuid)
 
 
-def virtual_interface_get_by_instance(context, instance_id, use_slave=False):
+def virtual_interface_get_by_instance(context, instance_id, use_subordinate=False):
     """Gets all virtual_interfaces for instance."""
     return IMPL.virtual_interface_get_by_instance(context, instance_id,
-                                                  use_slave=use_slave)
+                                                  use_subordinate=use_subordinate)
 
 
 def virtual_interface_get_by_instance_and_network(context, instance_id,
@@ -648,10 +648,10 @@ def instance_destroy(context, instance_uuid, constraint=None,
     return rv
 
 
-def instance_get_by_uuid(context, uuid, columns_to_join=None, use_slave=False):
+def instance_get_by_uuid(context, uuid, columns_to_join=None, use_subordinate=False):
     """Get an instance or raise if it does not exist."""
     return IMPL.instance_get_by_uuid(context, uuid,
-                                     columns_to_join, use_slave=use_slave)
+                                     columns_to_join, use_subordinate=use_subordinate)
 
 
 def instance_get(context, instance_id, columns_to_join=None):
@@ -667,7 +667,7 @@ def instance_get_all(context, columns_to_join=None):
 
 def instance_get_all_by_filters(context, filters, sort_key='created_at',
                                 sort_dir='desc', limit=None, marker=None,
-                                columns_to_join=None, use_slave=False):
+                                columns_to_join=None, use_subordinate=False):
     """Get all instances that match all filters."""
     # Note: This function exists for backwards compatibility since calls to
     # the instance layer coming in over RPC may specify the single sort
@@ -677,12 +677,12 @@ def instance_get_all_by_filters(context, filters, sort_key='created_at',
                                             sort_dir, limit=limit,
                                             marker=marker,
                                             columns_to_join=columns_to_join,
-                                            use_slave=use_slave)
+                                            use_subordinate=use_subordinate)
 
 
 def instance_get_all_by_filters_sort(context, filters, limit=None,
                                      marker=None, columns_to_join=None,
-                                     use_slave=False, sort_keys=None,
+                                     use_subordinate=False, sort_keys=None,
                                      sort_dirs=None):
     """Get all instances that match all filters sorted by multiple keys.
 
@@ -690,13 +690,13 @@ def instance_get_all_by_filters_sort(context, filters, limit=None,
     """
     return IMPL.instance_get_all_by_filters_sort(
         context, filters, limit=limit, marker=marker,
-        columns_to_join=columns_to_join, use_slave=use_slave,
+        columns_to_join=columns_to_join, use_subordinate=use_subordinate,
         sort_keys=sort_keys, sort_dirs=sort_dirs)
 
 
 def instance_get_active_by_window_joined(context, begin, end=None,
                                          project_id=None, host=None,
-                                         use_slave=False,
+                                         use_subordinate=False,
                                          columns_to_join=None):
     """Get instances and joins active during a certain time window.
 
@@ -705,16 +705,16 @@ def instance_get_active_by_window_joined(context, begin, end=None,
     """
     return IMPL.instance_get_active_by_window_joined(context, begin, end,
                                               project_id, host,
-                                              use_slave=use_slave,
+                                              use_subordinate=use_subordinate,
                                               columns_to_join=columns_to_join)
 
 
 def instance_get_all_by_host(context, host,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
     """Get all instances belonging to a host."""
     return IMPL.instance_get_all_by_host(context, host,
                                          columns_to_join,
-                                         use_slave=use_slave)
+                                         use_subordinate=use_subordinate)
 
 
 def instance_get_all_by_host_and_node(context, host, node,
@@ -1226,11 +1226,11 @@ def block_device_mapping_update_or_create(context, values, legacy=True):
 
 
 def block_device_mapping_get_all_by_instance(context, instance_uuid,
-                                             use_slave=False):
+                                             use_subordinate=False):
     """Get all block device mapping belonging to an instance."""
     return IMPL.block_device_mapping_get_all_by_instance(context,
                                                          instance_uuid,
-                                                         use_slave)
+                                                         use_subordinate)
 
 
 def block_device_mapping_get_by_volume_id(context, volume_id,
@@ -1657,16 +1657,16 @@ def agent_build_update(context, agent_build_id, values):
 ####################
 
 
-def bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+def bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
     """Return bw usage for instance and mac in a given audit period."""
     return IMPL.bw_usage_get(context, uuid, start_period, mac,
-                             use_slave=use_slave)
+                             use_subordinate=use_subordinate)
 
 
-def bw_usage_get_by_uuids(context, uuids, start_period, use_slave=False):
+def bw_usage_get_by_uuids(context, uuids, start_period, use_subordinate=False):
     """Return bw usages for instance(s) in a given audit period."""
     return IMPL.bw_usage_get_by_uuids(context, uuids, start_period,
-                                      use_slave=use_slave)
+                                      use_subordinate=use_subordinate)
 
 
 def bw_usage_update(context, uuid, mac, start_period, bw_in, bw_out,

--- a/nova/nova/db/sqlalchemy/api.py
+++ b/nova/nova/db/sqlalchemy/api.py
@@ -94,14 +94,14 @@ def _create_facade_lazily():
     return _ENGINE_FACADE
 
 
-def get_engine(use_slave=False):
+def get_engine(use_subordinate=False):
     facade = _create_facade_lazily()
-    return facade.get_engine(use_slave=use_slave)
+    return facade.get_engine(use_subordinate=use_subordinate)
 
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     facade = _create_facade_lazily()
-    return facade.get_session(use_slave=use_slave, **kwargs)
+    return facade.get_session(use_subordinate=use_subordinate, **kwargs)
 
 
 _SHADOW_TABLE_PREFIX = 'shadow_'
@@ -195,7 +195,7 @@ def _retry_on_deadlock(f):
 def model_query(context, model,
                 args=None,
                 session=None,
-                use_slave=False,
+                use_subordinate=False,
                 read_deleted=None,
                 project_only=False):
     """Query helper that accounts for context's `read_deleted` field.
@@ -204,7 +204,7 @@ def model_query(context, model,
     :param model:       Model to query. Must be a subclass of ModelBase.
     :param args:        Arguments to query. If None - model is used.
     :param session:     If present, the session to use.
-    :param use_slave:   If true, use a slave connection to the DB if creating a
+    :param use_subordinate:   If true, use a subordinate connection to the DB if creating a
                         session.
     :param read_deleted: If not None, overrides context's read_deleted field.
                         Permitted values are 'no', which does not return
@@ -217,9 +217,9 @@ def model_query(context, model,
     """
 
     if session is None:
-        if CONF.database.slave_connection == '':
-            use_slave = False
-        session = get_session(use_slave=use_slave)
+        if CONF.database.subordinate_connection == '':
+            use_subordinate = False
+        session = get_session(use_subordinate=use_subordinate)
 
     if read_deleted is None:
         read_deleted = context.read_deleted
@@ -361,9 +361,9 @@ def service_destroy(context, service_id):
 
 
 def _service_get(context, service_id, with_compute_node=True, session=None,
-                 use_slave=False):
+                 use_subordinate=False):
     query = model_query(context, models.Service, session=session,
-                        use_slave=use_slave).\
+                        use_subordinate=use_subordinate).\
                      filter_by(id=service_id)
 
     if with_compute_node:
@@ -378,10 +378,10 @@ def _service_get(context, service_id, with_compute_node=True, session=None,
 
 @require_admin_context
 def service_get(context, service_id, with_compute_node=False,
-                use_slave=False):
+                use_subordinate=False):
     return _service_get(context, service_id,
                         with_compute_node=with_compute_node,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
 
 
 @require_admin_context
@@ -419,9 +419,9 @@ def service_get_all_by_host(context, host):
 
 
 @require_admin_context
-def service_get_by_compute_host(context, host, use_slave=False):
+def service_get_by_compute_host(context, host, use_subordinate=False):
     result = model_query(context, models.Service, read_deleted="no",
-                         use_slave=use_slave).\
+                         use_subordinate=use_subordinate).\
                 options(joinedload('compute_node')).\
                 filter_by(host=host).\
                 filter_by(topic=CONF.compute_topic).\
@@ -518,9 +518,9 @@ def compute_node_get_by_host_and_nodename(context, host, nodename):
 
 
 @require_admin_context
-def compute_node_get_all_by_host(context, host, use_slave=False):
+def compute_node_get_all_by_host(context, host, use_subordinate=False):
     result = model_query(context, models.ComputeNode, read_deleted='no',
-                         use_slave=use_slave).\
+                         use_subordinate=use_subordinate).\
         filter_by(host=host).\
         all()
 
@@ -1385,9 +1385,9 @@ def virtual_interface_create(context, values):
     return vif_ref
 
 
-def _virtual_interface_query(context, session=None, use_slave=False):
+def _virtual_interface_query(context, session=None, use_subordinate=False):
     return model_query(context, models.VirtualInterface, session=session,
-                       read_deleted="no", use_slave=use_slave)
+                       read_deleted="no", use_subordinate=use_subordinate)
 
 
 @require_context
@@ -1433,12 +1433,12 @@ def virtual_interface_get_by_uuid(context, vif_uuid):
 
 @require_context
 @require_instance_exists_using_uuid
-def virtual_interface_get_by_instance(context, instance_uuid, use_slave=False):
+def virtual_interface_get_by_instance(context, instance_uuid, use_subordinate=False):
     """Gets all virtual interfaces for instance.
 
     :param instance_uuid: = uuid of the instance to retrieve vifs for
     """
-    vif_refs = _virtual_interface_query(context, use_slave=use_slave).\
+    vif_refs = _virtual_interface_query(context, use_subordinate=use_subordinate).\
                        filter_by(instance_uuid=instance_uuid).\
                        order_by(asc("created_at"), asc("id")).\
                        all()
@@ -1657,16 +1657,16 @@ def instance_destroy(context, instance_uuid, constraint=None):
 
 
 @require_context
-def instance_get_by_uuid(context, uuid, columns_to_join=None, use_slave=False):
+def instance_get_by_uuid(context, uuid, columns_to_join=None, use_subordinate=False):
     return _instance_get_by_uuid(context, uuid,
-            columns_to_join=columns_to_join, use_slave=use_slave)
+            columns_to_join=columns_to_join, use_subordinate=use_subordinate)
 
 
 def _instance_get_by_uuid(context, uuid, session=None,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     result = _build_instance_get(context, session=session,
                                  columns_to_join=columns_to_join,
-                                 use_slave=use_slave).\
+                                 use_subordinate=use_subordinate).\
                 filter_by(uuid=uuid).\
                 first()
 
@@ -1695,9 +1695,9 @@ def instance_get(context, instance_id, columns_to_join=None):
 
 
 def _build_instance_get(context, session=None,
-                        columns_to_join=None, use_slave=False):
+                        columns_to_join=None, use_subordinate=False):
     query = model_query(context, models.Instance, session=session,
-                        project_only=True, use_slave=use_slave).\
+                        project_only=True, use_subordinate=use_subordinate).\
             options(joinedload_all('security_groups.rules')).\
             options(joinedload('info_cache'))
     if columns_to_join is None:
@@ -1718,7 +1718,7 @@ def _build_instance_get(context, session=None,
 
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
 
@@ -1736,13 +1736,13 @@ def _instances_fill_metadata(context, instances,
     meta = collections.defaultdict(list)
     if 'metadata' in manual_joins:
         for row in _instance_metadata_get_multi(context, uuids,
-                                                use_slave=use_slave):
+                                                use_subordinate=use_subordinate):
             meta[row['instance_uuid']].append(row)
 
     sys_meta = collections.defaultdict(list)
     if 'system_metadata' in manual_joins:
         for row in _instance_system_metadata_get_multi(context, uuids,
-                                                       use_slave=use_slave):
+                                                       use_subordinate=use_subordinate):
             sys_meta[row['instance_uuid']].append(row)
 
     pcidevs = collections.defaultdict(list)
@@ -1809,7 +1809,7 @@ def instance_get_all(context, columns_to_join=None):
 @require_context
 def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
                                 limit=None, marker=None, columns_to_join=None,
-                                use_slave=False):
+                                use_subordinate=False):
     """Return instances matching all filters sorted by the primary key.
 
     See instance_get_all_by_filters_sort for more information.
@@ -1819,14 +1819,14 @@ def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
     return instance_get_all_by_filters_sort(context, filters, limit=limit,
                                             marker=marker,
                                             columns_to_join=columns_to_join,
-                                            use_slave=use_slave,
+                                            use_subordinate=use_subordinate,
                                             sort_keys=[sort_key],
                                             sort_dirs=[sort_dir])
 
 
 @require_context
 def instance_get_all_by_filters_sort(context, filters, limit=None, marker=None,
-                                     columns_to_join=None, use_slave=False,
+                                     columns_to_join=None, use_subordinate=False,
                                      sort_keys=None, sort_dirs=None):
     """Return instances that match all filters sorted the the given keys.
     Deleted instances will be returned by default, unless there's a filter that
@@ -1888,10 +1888,10 @@ def instance_get_all_by_filters_sort(context, filters, limit=None, marker=None,
                                                sort_dirs,
                                                default_dir='desc')
 
-    if CONF.database.slave_connection == '':
-        use_slave = False
+    if CONF.database.subordinate_connection == '':
+        use_subordinate = False
 
-    session = get_session(use_slave=use_slave)
+    session = get_session(use_subordinate=use_subordinate)
 
     if columns_to_join is None:
         columns_to_join_new = ['info_cache', 'security_groups']
@@ -2229,10 +2229,10 @@ def process_sort_params(sort_keys, sort_dirs,
 @require_context
 def instance_get_active_by_window_joined(context, begin, end=None,
                                          project_id=None, host=None,
-                                         use_slave=False,
+                                         use_subordinate=False,
                                          columns_to_join=None):
     """Return instances and joins that were active during window."""
-    session = get_session(use_slave=use_slave)
+    session = get_session(use_subordinate=use_subordinate)
     query = session.query(models.Instance)
 
     if columns_to_join is None:
@@ -2261,14 +2261,14 @@ def instance_get_active_by_window_joined(context, begin, end=None,
 
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     for column in joins:
         if 'extra.' in column:
             query = query.options(undefer(column))
@@ -2280,12 +2280,12 @@ def _instance_get_all_query(context, project_only=False,
 @require_admin_context
 def instance_get_all_by_host(context, host,
                              columns_to_join=None,
-                             use_slave=False):
+                             use_subordinate=False):
     return _instances_fill_metadata(context,
       _instance_get_all_query(context,
-                              use_slave=use_slave).filter_by(host=host).all(),
+                              use_subordinate=use_subordinate).filter_by(host=host).all(),
                               manual_joins=columns_to_join,
-                              use_slave=use_slave)
+                              use_subordinate=use_subordinate)
 
 
 def _instance_get_all_uuids_by_host(context, host, session=None):
@@ -3707,12 +3707,12 @@ def ec2_snapshot_get_by_uuid(context, snapshot_uuid):
 
 
 def _block_device_mapping_get_query(context, session=None,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     if columns_to_join is None:
         columns_to_join = []
 
     query = model_query(context, models.BlockDeviceMapping,
-                        session=session, use_slave=use_slave)
+                        session=session, use_subordinate=use_subordinate)
 
     for column in columns_to_join:
         query = query.options(joinedload(column))
@@ -3794,8 +3794,8 @@ def block_device_mapping_update_or_create(context, values, legacy=True):
 
 @require_context
 def block_device_mapping_get_all_by_instance(context, instance_uuid,
-                                             use_slave=False):
-    return _block_device_mapping_get_query(context, use_slave=use_slave).\
+                                             use_subordinate=False):
+    return _block_device_mapping_get_query(context, use_subordinate=use_subordinate).\
                  filter_by(instance_uuid=instance_uuid).\
                  all()
 
@@ -4311,12 +4311,12 @@ def migration_get_by_instance_and_status(context, instance_uuid, status):
 
 @require_admin_context
 def migration_get_unconfirmed_by_dest_compute(context, confirm_window,
-                                              dest_compute, use_slave=False):
+                                              dest_compute, use_subordinate=False):
     confirm_window = (timeutils.utcnow() -
                       datetime.timedelta(seconds=confirm_window))
 
     return model_query(context, models.Migration, read_deleted="yes",
-                       use_slave=use_slave).\
+                       use_subordinate=use_subordinate).\
              filter(models.Migration.updated_at <= confirm_window).\
              filter_by(status="finished").\
              filter_by(dest_compute=dest_compute).\
@@ -4824,11 +4824,11 @@ def cell_get_all(context):
 # User-provided metadata
 
 def _instance_metadata_get_multi(context, instance_uuids,
-                                 session=None, use_slave=False):
+                                 session=None, use_subordinate=False):
     if not instance_uuids:
         return []
     return model_query(context, models.InstanceMetadata,
-                       session=session, use_slave=use_slave).\
+                       session=session, use_subordinate=use_subordinate).\
                     filter(
             models.InstanceMetadata.instance_uuid.in_(instance_uuids))
 
@@ -4890,11 +4890,11 @@ def instance_metadata_update(context, instance_uuid, metadata, delete):
 
 
 def _instance_system_metadata_get_multi(context, instance_uuids,
-                                        session=None, use_slave=False):
+                                        session=None, use_subordinate=False):
     if not instance_uuids:
         return []
     return model_query(context, models.InstanceSystemMetadata,
-                       session=session, use_slave=use_slave).\
+                       session=session, use_subordinate=use_subordinate).\
                     filter(
             models.InstanceSystemMetadata.instance_uuid.in_(instance_uuids))
 
@@ -4997,9 +4997,9 @@ def agent_build_update(context, agent_build_id, values):
 ####################
 
 @require_context
-def bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+def bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
     return model_query(context, models.BandwidthUsage, read_deleted="yes",
-                       use_slave=use_slave).\
+                       use_subordinate=use_subordinate).\
                            filter_by(start_period=start_period).\
                            filter_by(uuid=uuid).\
                            filter_by(mac=mac).\
@@ -5007,10 +5007,10 @@ def bw_usage_get(context, uuid, start_period, mac, use_slave=False):
 
 
 @require_context
-def bw_usage_get_by_uuids(context, uuids, start_period, use_slave=False):
+def bw_usage_get_by_uuids(context, uuids, start_period, use_subordinate=False):
     return (
         model_query(context, models.BandwidthUsage, read_deleted="yes",
-                    use_slave=use_slave).
+                    use_subordinate=use_subordinate).
         filter(models.BandwidthUsage.uuid.in_(uuids)).
         filter_by(start_period=start_period).
         all()

--- a/nova/nova/network/ldapdns.py
+++ b/nova/nova/network/ldapdns.py
@@ -42,9 +42,9 @@ ldap_dns_opts = [
                default='password',
                help='Password for LDAP DNS',
                secret=True),
-    cfg.StrOpt('ldap_dns_soa_hostmaster',
-               default='hostmaster@example.org',
-               help='Hostmaster for LDAP DNS driver Statement of Authority'),
+    cfg.StrOpt('ldap_dns_soa_hostmain',
+               default='hostmain@example.org',
+               help='Hostmain for LDAP DNS driver Statement of Authority'),
     cfg.MultiStrOpt('ldap_dns_servers',
                     default=['dns.example.org'],
                     help='DNS Servers for LDAP DNS driver'),
@@ -156,7 +156,7 @@ class DomainEntry(DNSEntry):
         date = time.strftime('%Y%m%d%H%M%S')
         soa = '%s %s %s %s %s %s %s' % (
                  CONF.ldap_dns_servers[0],
-                 CONF.ldap_dns_soa_hostmaster,
+                 CONF.ldap_dns_soa_hostmain,
                  date,
                  CONF.ldap_dns_soa_refresh,
                  CONF.ldap_dns_soa_retry,

--- a/nova/nova/network/linux_net.py
+++ b/nova/nova/network/linux_net.py
@@ -1585,7 +1585,7 @@ class LinuxBridgeInterfaceDriver(LinuxNetInterfaceDriver):
             out, err = _execute('brctl', 'addif', bridge, interface,
                                 check_exit_code=False, run_as_root=True)
             if (err and err != "device %s is already a member of a bridge; "
-                     "can't enslave it to bridge %s.\n" % (interface, bridge)):
+                     "can't ensubordinate it to bridge %s.\n" % (interface, bridge)):
                 msg = _('Failed to add interface: %s') % err
                 raise exception.NovaException(msg)
 

--- a/nova/nova/network/neutronv2/api.py
+++ b/nova/nova/network/neutronv2/api.py
@@ -669,14 +669,14 @@ class API(base_api.NetworkAPI):
             raise exception.Forbidden()
 
     def get_instance_nw_info(self, context, instance, networks=None,
-                             port_ids=None, use_slave=False,
+                             port_ids=None, use_subordinate=False,
                              admin_client=None):
         """Return network information for specified instance
            and update cache.
         """
-        # NOTE(geekinutah): It would be nice if use_slave had us call
-        #                   special APIs that pummeled slaves instead of
-        #                   the master. For now we just ignore this arg.
+        # NOTE(geekinutah): It would be nice if use_subordinate had us call
+        #                   special APIs that pummeled subordinates instead of
+        #                   the main. For now we just ignore this arg.
         with lockutils.lock('refresh_cache-%s' % instance['uuid']):
             result = self._get_instance_nw_info(context, instance, networks,
                                                 port_ids, admin_client)

--- a/nova/nova/objects/bandwidth_usage.py
+++ b/nova/nova/objects/bandwidth_usage.py
@@ -19,7 +19,7 @@ from nova.objects import fields
 class BandwidthUsage(base.NovaPersistentObject, base.NovaObject,
                      base.NovaObjectDictCompat):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_instance_uuid_and_mac
+    # Version 1.1: Add use_subordinate to get_by_instance_uuid_and_mac
     # Version 1.2: Add update_cells to create
     VERSION = '1.2'
 
@@ -45,10 +45,10 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject,
     @base.serialize_args
     @base.remotable_classmethod
     def get_by_instance_uuid_and_mac(cls, context, instance_uuid, mac,
-                                     start_period=None, use_slave=False):
+                                     start_period=None, use_subordinate=False):
         db_bw_usage = db.bw_usage_get(context, uuid=instance_uuid,
                                       start_period=start_period, mac=mac,
-                                      use_slave=use_slave)
+                                      use_subordinate=use_subordinate)
         if db_bw_usage:
             return cls._from_db_object(context, cls(), db_bw_usage)
 
@@ -67,7 +67,7 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject,
 
 class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_uuids
+    # Version 1.1: Add use_subordinate to get_by_uuids
     # Version 1.2: BandwidthUsage <= version 1.2
     VERSION = '1.2'
     fields = {
@@ -81,8 +81,8 @@ class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
 
     @base.serialize_args
     @base.remotable_classmethod
-    def get_by_uuids(cls, context, uuids, start_period=None, use_slave=False):
+    def get_by_uuids(cls, context, uuids, start_period=None, use_subordinate=False):
         db_bw_usages = db.bw_usage_get_by_uuids(context, uuids=uuids,
                                                 start_period=start_period,
-                                                use_slave=use_slave)
+                                                use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(), BandwidthUsage, db_bw_usages)

--- a/nova/nova/objects/block_device.py
+++ b/nova/nova/objects/block_device.py
@@ -199,7 +199,7 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject,
 class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     # Version 1.1: BlockDeviceMapping <= version 1.1
-    # Version 1.2: Added use_slave to get_by_instance_uuid
+    # Version 1.2: Added use_subordinate to get_by_instance_uuid
     # Version 1.3: BlockDeviceMapping <= version 1.2
     # Version 1.4: BlockDeviceMapping <= version 1.3
     # Version 1.5: BlockDeviceMapping <= version 1.4
@@ -220,9 +220,9 @@ class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     }
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_bdms = db.block_device_mapping_get_all_by_instance(
-                context, instance_uuid, use_slave=use_slave)
+                context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 

--- a/nova/nova/objects/compute_node.py
+++ b/nova/nova/objects/compute_node.py
@@ -200,8 +200,8 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject,
 
     @base.remotable_classmethod
     def get_first_node_by_host_for_old_compat(cls, context, host,
-                                              use_slave=False):
-        computes = ComputeNodeList.get_all_by_host(context, host, use_slave)
+                                              use_subordinate=False):
+        computes = ComputeNodeList.get_all_by_host(context, host, use_subordinate)
         # FIXME(sbauza): Some hypervisors (VMware, Ironic) can return multiple
         # nodes per host, we should return all the nodes and modify the callers
         # instead.
@@ -280,7 +280,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # Version 1.2 Add get_by_service()
     # Version 1.3 ComputeNode version 1.4
     # Version 1.4 ComputeNode version 1.5
-    # Version 1.5 Add use_slave to get_by_service
+    # Version 1.5 Add use_subordinate to get_by_service
     # Version 1.6 ComputeNode version 1.6
     # Version 1.7 ComputeNode version 1.7
     # Version 1.8 ComputeNode version 1.8 + add get_all_by_host()
@@ -319,7 +319,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
                                   db_computes)
 
     @base.remotable_classmethod
-    def _get_by_service(cls, context, service_id, use_slave=False):
+    def _get_by_service(cls, context, service_id, use_subordinate=False):
         try:
             db_computes = db.compute_nodes_get_by_service_id(
                 context, service_id)
@@ -331,14 +331,14 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
                                   db_computes)
 
     @classmethod
-    def get_by_service(cls, context, service, use_slave=False):
-        return cls._get_by_service(context, service.id, use_slave=use_slave)
+    def get_by_service(cls, context, service, use_subordinate=False):
+        return cls._get_by_service(context, service.id, use_subordinate=use_subordinate)
 
     @base.remotable_classmethod
-    def get_all_by_host(cls, context, host, use_slave=False):
+    def get_all_by_host(cls, context, host, use_subordinate=False):
         try:
             db_computes = db.compute_node_get_all_by_host(context, host,
-                                                          use_slave)
+                                                          use_subordinate)
         except exception.ComputeHostNotFound:
             # FIXME(sbauza): Some old computes can still have no host record
             # We need to provide compatibility by using the old service_id
@@ -347,7 +347,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
             # call but that's necessary until all nodes are upgraded.
             try:
                 service = objects.Service.get_by_compute_host(context, host,
-                                                              use_slave)
+                                                              use_subordinate)
                 db_computes = db.compute_nodes_get_by_service_id(
                     context, service.id)
             except exception.ServiceNotFound:

--- a/nova/nova/objects/instance.py
+++ b/nova/nova/objects/instance.py
@@ -81,7 +81,7 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
     # Version 1.7: String attributes updated to support unicode
     # Version 1.8: 'security_groups' and 'pci_devices' cannot be None
     # Version 1.9: Make uuid a non-None real string
-    # Version 1.10: Added use_slave to refresh and get_by_uuid
+    # Version 1.10: Added use_subordinate to refresh and get_by_uuid
     # Version 1.11: Update instance from database during destroy
     # Version 1.12: Added ephemeral_key_uuid
     # Version 1.13: Added delete_metadata_key()
@@ -340,13 +340,13 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         return instance
 
     @base.remotable_classmethod
-    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_slave=False):
+    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_subordinate=False):
         if expected_attrs is None:
             expected_attrs = ['info_cache', 'security_groups']
         columns_to_join = _expected_cols(expected_attrs)
         db_inst = db.instance_get_by_uuid(context, uuid,
                                           columns_to_join=columns_to_join,
-                                          use_slave=use_slave)
+                                          use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_inst,
                                    expected_attrs)
 
@@ -550,12 +550,12 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         self.obj_reset_changes()
 
     @base.remotable
-    def refresh(self, context, use_slave=False):
+    def refresh(self, context, use_subordinate=False):
         extra = [field for field in INSTANCE_OPTIONAL_ATTRS
                        if self.obj_attr_is_set(field)]
         current = self.__class__.get_by_uuid(context, uuid=self.uuid,
                                              expected_attrs=extra,
-                                             use_slave=use_slave)
+                                             use_subordinate=use_subordinate)
         # NOTE(danms): We orphan the instance copy so we do not unexpectedly
         # trigger a lazy-load (which would mean we failed to calculate the
         # expected_attrs properly)
@@ -703,14 +703,14 @@ def _make_instance_list(context, inst_list, db_inst_list, expected_attrs):
 
 class InstanceList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Added use_slave to get_by_host
+    # Version 1.1: Added use_subordinate to get_by_host
     #              Instance <= version 1.9
     # Version 1.2: Instance <= version 1.11
-    # Version 1.3: Added use_slave to get_by_filters
+    # Version 1.3: Added use_subordinate to get_by_filters
     # Version 1.4: Instance <= version 1.12
     # Version 1.5: Added method get_active_by_window_joined.
     # Version 1.6: Instance <= version 1.13
-    # Version 1.7: Added use_slave to get_active_by_window_joined
+    # Version 1.7: Added use_subordinate to get_active_by_window_joined
     # Version 1.8: Instance <= version 1.14
     # Version 1.9: Instance <= version 1.15
     # Version 1.10: Instance <= version 1.16
@@ -742,26 +742,26 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def get_by_filters(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False,
+                       marker=None, expected_attrs=None, use_subordinate=False,
                        sort_keys=None, sort_dirs=None):
         if sort_keys or sort_dirs:
             db_inst_list = db.instance_get_all_by_filters_sort(
                 context, filters, limit=limit, marker=marker,
                 columns_to_join=_expected_cols(expected_attrs),
-                use_slave=use_slave, sort_keys=sort_keys, sort_dirs=sort_dirs)
+                use_subordinate=use_subordinate, sort_keys=sort_keys, sort_dirs=sort_dirs)
         else:
             db_inst_list = db.instance_get_all_by_filters(
                 context, filters, sort_key, sort_dir, limit=limit,
                 marker=marker, columns_to_join=_expected_cols(expected_attrs),
-                use_slave=use_slave)
+                use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
     @base.remotable_classmethod
-    def get_by_host(cls, context, host, expected_attrs=None, use_slave=False):
+    def get_by_host(cls, context, host, expected_attrs=None, use_subordinate=False):
         db_inst_list = db.instance_get_all_by_host(
             context, host, columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
@@ -793,7 +793,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     def _get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
                                     expected_attrs=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
         # NOTE(mriedem): We need to convert the begin/end timestamp strings
         # to timezone-aware datetime objects for the DB API call.
         begin = timeutils.parse_isotime(begin)
@@ -808,7 +808,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     def get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
                                     expected_attrs=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
         """Get instances and joins active during a certain time window.
 
         :param:context: nova request context
@@ -818,7 +818,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         :param:host: used to filter instances on a given compute host
         :param:expected_attrs: list of related fields that can be joined
         in the database layer when querying for instances
-        :param use_slave if True, ship this query off to a DB slave
+        :param use_subordinate if True, ship this query off to a DB subordinate
         :returns: InstanceList
 
         """
@@ -829,7 +829,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         return cls._get_active_by_window_joined(context, begin, end,
                                                 project_id, host,
                                                 expected_attrs,
-                                                use_slave=use_slave)
+                                                use_subordinate=use_subordinate)
 
     @base.remotable_classmethod
     def get_by_security_group_id(cls, context, security_group_id):

--- a/nova/nova/objects/migration.py
+++ b/nova/nova/objects/migration.py
@@ -83,7 +83,7 @@ class Migration(base.NovaPersistentObject, base.NovaObject,
 class MigrationList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     #              Migration <= 1.1
-    # Version 1.1: Added use_slave to get_unconfirmed_by_dest_compute
+    # Version 1.1: Added use_subordinate to get_unconfirmed_by_dest_compute
     VERSION = '1.1'
 
     fields = {
@@ -97,9 +97,9 @@ class MigrationList(base.ObjectListBase, base.NovaObject):
 
     @base.remotable_classmethod
     def get_unconfirmed_by_dest_compute(cls, context, confirm_window,
-                                        dest_compute, use_slave=False):
+                                        dest_compute, use_subordinate=False):
         db_migrations = db.migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=use_slave)
+            context, confirm_window, dest_compute, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.Migration,
                                   db_migrations)
 

--- a/nova/nova/objects/service.py
+++ b/nova/nova/objects/service.py
@@ -31,7 +31,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
     # Version 1.1: Added compute_node nested object
     # Version 1.2: String attributes updated to support unicode
     # Version 1.3: ComputeNode version 1.5
-    # Version 1.4: Added use_slave to get_by_compute_host
+    # Version 1.4: Added use_subordinate to get_by_compute_host
     # Version 1.5: ComputeNode version 1.6
     # Version 1.6: ComputeNode version 1.7
     # Version 1.7: ComputeNode version 1.8
@@ -109,7 +109,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
         return cls._from_db_object(context, cls(), db_service)
 
     @base.remotable_classmethod
-    def get_by_compute_host(cls, context, host, use_slave=False):
+    def get_by_compute_host(cls, context, host, use_subordinate=False):
         db_service = db.service_get_by_compute_host(context, host)
         return cls._from_db_object(context, cls(), db_service)
 

--- a/nova/nova/objects/virtual_interface.py
+++ b/nova/nova/objects/virtual_interface.py
@@ -97,8 +97,8 @@ class VirtualInterfaceList(base.ObjectListBase, base.NovaObject):
                                   objects.VirtualInterface, db_vifs)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_vifs = db.virtual_interface_get_by_instance(context, instance_uuid,
-                use_slave=use_slave)
+                use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context),
                                   objects.VirtualInterface, db_vifs)

--- a/nova/nova/tests/functional/test_api_samples.py
+++ b/nova/nova/tests/functional/test_api_samples.py
@@ -3551,7 +3551,7 @@ class VolumeAttachmentsSampleBase(ServersSampleBase):
     def _stub_db_bdms_get_all_by_instance(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/nova/tests/functional/v3/test_extended_volumes.py
+++ b/nova/nova/tests/functional/v3/test_extended_volumes.py
@@ -31,7 +31,7 @@ class ExtendedVolumesSampleJsonTests(test_servers.ServersSampleBase):
     def _stub_compute_api_get_instance_bdms(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/nova/tests/functional/v3/test_volumes.py
+++ b/nova/nova/tests/functional/v3/test_volumes.py
@@ -195,7 +195,7 @@ class VolumeAttachmentsSampleBase(test_servers.ServersSampleBase):
     def _stub_db_bdms_get_all_by_instance(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/nova/tests/unit/api/ec2/test_cloud.py
+++ b/nova/nova/tests/unit/api/ec2/test_cloud.py
@@ -2523,7 +2523,7 @@ class CloudTestCase(test.TestCase):
         self.stubs.Set(fake._FakeImageService, 'show', fake_show)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': volumes[0],
                          'snapshot_id': snapshots[0],
@@ -2599,7 +2599,7 @@ class CloudTestCase(test.TestCase):
         ec2_instance_id = self._run_instance(**kwargs)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': volumes[0],
                          'snapshot_id': snapshots[0],
@@ -2620,7 +2620,7 @@ class CloudTestCase(test.TestCase):
                           no_reboot=True)
 
     @staticmethod
-    def _fake_bdm_get(ctxt, id, use_slave=False):
+    def _fake_bdm_get(ctxt, id, use_subordinate=False):
         blockdms = [{'volume_id': 87654321,
                      'source_type': 'volume',
                      'destination_type': 'volume',

--- a/nova/nova/tests/unit/api/openstack/compute/contrib/test_disk_config.py
+++ b/nova/nova/tests/unit/api/openstack/compute/contrib/test_disk_config.py
@@ -66,7 +66,7 @@ class DiskConfigTestCaseV21(test.TestCase):
         self.stubs.Set(db, 'instance_get', fake_instance_get)
 
         def fake_instance_get_by_uuid(context, uuid,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             for instance in FAKE_INSTANCES:
                 if uuid == instance['uuid']:
                     return instance

--- a/nova/nova/tests/unit/api/openstack/compute/contrib/test_instance_actions.py
+++ b/nova/nova/tests/unit/api/openstack/compute/contrib/test_instance_actions.py
@@ -90,7 +90,7 @@ class InstanceActionsPolicyTestV21(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -105,7 +105,7 @@ class InstanceActionsPolicyTestV21(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -139,7 +139,7 @@ class InstanceActionsTestV21(test.NoDBTestCase):
                      want_objects=False):
             return {'uuid': instance_uuid}
 
-        def fake_instance_get_by_uuid(context, instance_id, use_slave=False):
+        def fake_instance_get_by_uuid(context, instance_id, use_subordinate=False):
             return {'name': 'fake', 'project_id': context.project_id}
 
         self.stubs.Set(compute_api.API, 'get', fake_get)

--- a/nova/nova/tests/unit/api/openstack/compute/contrib/test_security_groups.py
+++ b/nova/nova/tests/unit/api/openstack/compute/contrib/test_security_groups.py
@@ -80,7 +80,7 @@ def security_group_rule_db(rule, id=None):
 
 
 def return_server(context, server_id,
-                  columns_to_join=None, use_slave=False):
+                  columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': int(server_id),
            'power_state': 0x01,
@@ -91,7 +91,7 @@ def return_server(context, server_id,
 
 def return_server_by_uuid(context, server_uuid,
                           columns_to_join=None,
-                          use_slave=False):
+                          use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'power_state': 0x01,
@@ -418,7 +418,7 @@ class TestSecurityGroupsV21(test.TestCase):
         expected = {'security_groups': groups}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
 
@@ -445,7 +445,7 @@ class TestSecurityGroupsV21(test.TestCase):
         expected = {'security_groups': []}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
         mock_db_get_ins.side_effect = return_instance

--- a/nova/nova/tests/unit/api/openstack/compute/contrib/test_server_start_stop.py
+++ b/nova/nova/tests/unit/api/openstack/compute/contrib/test_server_start_stop.py
@@ -30,7 +30,7 @@ from nova.tests.unit.api.openstack import fakes
 
 
 def fake_instance_get(context, instance_id,
-                      columns_to_join=None, use_slave=False):
+                      columns_to_join=None, use_subordinate=False):
     result = fakes.stub_instance(id=1, uuid=instance_id)
     result['created_at'] = None
     result['deleted_at'] = None

--- a/nova/nova/tests/unit/api/openstack/compute/contrib/test_shelve.py
+++ b/nova/nova/tests/unit/api/openstack/compute/contrib/test_shelve.py
@@ -29,7 +29,7 @@ from nova.tests.unit import fake_instance
 
 
 def fake_instance_get_by_uuid(context, instance_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'name': 'fake', 'project_id': '%s_unequal' % context.project_id})
 

--- a/nova/nova/tests/unit/api/openstack/compute/contrib/test_simple_tenant_usage.py
+++ b/nova/nova/tests/unit/api/openstack/compute/contrib/test_simple_tenant_usage.py
@@ -163,11 +163,11 @@ class SimpleTenantUsageTestV21(test.TestCase):
         def fake_get_active_by_window_joined(context, begin, end=None,
                                     project_id=None, host=None,
                                     expected_attrs=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
             self.assertEqual(['system_metadata'], expected_attrs)
             return orig_get_active_by_window_joined(context, begin, end,
                                                     project_id, host,
-                                                    expected_attrs, use_slave)
+                                                    expected_attrs, use_subordinate)
 
         with mock.patch.object(objects.InstanceList,
                                'get_active_by_window_joined',

--- a/nova/nova/tests/unit/api/openstack/compute/contrib/test_volumes.py
+++ b/nova/nova/tests/unit/api/openstack/compute/contrib/test_volumes.py
@@ -99,7 +99,7 @@ def fake_compute_volume_snapshot_create(self, context, volume_id,
     pass
 
 
-def fake_bdms_get_all_by_instance(context, instance_uuid, use_slave=False):
+def fake_bdms_get_all_by_instance(context, instance_uuid, use_subordinate=False):
     return [fake_block_device.FakeDbBlockDeviceDict(
             {'id': 1,
              'instance_uuid': instance_uuid,

--- a/nova/nova/tests/unit/api/openstack/compute/plugins/v3/test_servers.py
+++ b/nova/nova/tests/unit/api/openstack/compute/plugins/v3/test_servers.py
@@ -114,7 +114,7 @@ def fake_start_stop_invalid_state(self, context, instance):
 
 
 def fake_instance_get_by_uuid_not_found(context, uuid,
-                                        columns_to_join, use_slave=False):
+                                        columns_to_join, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=uuid)
 
 
@@ -705,7 +705,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_tenant_id_filter_converts_to_project_id_for_admin(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'newfake')
@@ -723,7 +723,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_tenant_id_filter_no_admin_context(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertNotEqual(filters, None)
             self.assertEqual(filters['project_id'], 'fake')
@@ -738,7 +738,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_all_tenants_param_normal(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
@@ -753,7 +753,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_all_tenants_param_one(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
@@ -768,7 +768,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_all_tenants_param_zero(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
@@ -783,7 +783,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_all_tenants_param_false(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
@@ -813,7 +813,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_admin_restricted_tenant(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'fake')
@@ -829,7 +829,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_all_tenants_pass_policy(self):
         def fake_get_all(context, filters=None, limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=None, sort_keys=None, sort_dirs=None):
             self.assertIsNotNone(filters)
             self.assertNotIn('project_id', filters)

--- a/nova/nova/tests/unit/api/openstack/compute/test_server_actions.py
+++ b/nova/nova/tests/unit/api/openstack/compute/test_server_actions.py
@@ -526,7 +526,7 @@ class ServerActionsControllerTestV21(test.TestCase):
 
     def test_rebuild_server_not_found(self):
         def server_not_found(self, instance_id,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
             raise exception.InstanceNotFound(instance_id=instance_id)
         self.stubs.Set(db, 'instance_get_by_uuid', server_not_found)
 
@@ -1008,7 +1008,7 @@ class ServerActionsControllerTestV21(test.TestCase):
         image_service.create(None, original_image)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -1088,7 +1088,7 @@ class ServerActionsControllerTestV21(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/nova/nova/tests/unit/api/openstack/compute/test_server_metadata.py
+++ b/nova/nova/tests/unit/api/openstack/compute/test_server_metadata.py
@@ -93,7 +93,7 @@ def return_server(context, server_id, columns_to_join=None):
 
 
 def return_server_by_uuid(context, server_uuid,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',
@@ -105,7 +105,7 @@ def return_server_by_uuid(context, server_uuid,
 
 
 def return_server_nonexistent(context, server_id,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 
@@ -737,7 +737,7 @@ class BadStateServerMetaDataTestV21(test.TestCase):
                'vm_state': vm_states.BUILDING})
 
     def _return_server_in_build_by_uuid(self, context, server_uuid,
-                                        columns_to_join=None, use_slave=False):
+                                        columns_to_join=None, use_subordinate=False):
         return fake_instance.fake_db_instance(
             **{'id': 1,
                'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',

--- a/nova/nova/tests/unit/api/openstack/compute/test_servers.py
+++ b/nova/nova/tests/unit/api/openstack/compute/test_servers.py
@@ -687,7 +687,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_converts_to_project_id_for_admin(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'newfake')
             self.assertFalse(filters.get('tenant_id'))
@@ -705,7 +705,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_normal(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
 
@@ -720,7 +720,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_one(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
 
@@ -735,7 +735,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_zero(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
 
@@ -750,7 +750,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_false(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
 
@@ -780,7 +780,7 @@ class ServersControllerTest(ControllerTest):
     def test_admin_restricted_tenant(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'fake')
             return [fakes.stub_instance(100)]
@@ -796,7 +796,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_pass_policy(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]

--- a/nova/nova/tests/unit/api/openstack/fakes.py
+++ b/nova/nova/tests/unit/api/openstack/fakes.py
@@ -375,7 +375,7 @@ def get_fake_uuid(token=0):
 
 
 def fake_instance_get(**kwargs):
-    def _return_server(context, uuid, columns_to_join=None, use_slave=False):
+    def _return_server(context, uuid, columns_to_join=None, use_subordinate=False):
         return stub_instance(1, **kwargs)
     return _return_server
 
@@ -398,8 +398,8 @@ def fake_instance_get_all_by_filters(num_servers=5, **kwargs):
         if 'columns_to_join' in kwargs:
             kwargs.pop('columns_to_join')
 
-        if 'use_slave' in kwargs:
-            kwargs.pop('use_slave')
+        if 'use_subordinate' in kwargs:
+            kwargs.pop('use_subordinate')
 
         if 'sort_keys' in kwargs:
             kwargs.pop('sort_keys')
@@ -655,7 +655,7 @@ def stub_snapshot_get_all(self, context):
             stub_snapshot(102, project_id='superduperfake')]
 
 
-def stub_bdm_get_all_by_instance(context, instance_uuid, use_slave=False):
+def stub_bdm_get_all_by_instance(context, instance_uuid, use_subordinate=False):
     return [fake_block_device.FakeDbBlockDeviceDict(
             {'id': 1, 'source_type': 'volume', 'destination_type': 'volume',
             'volume_id': 'volume_id1', 'instance_uuid': instance_uuid}),

--- a/nova/nova/tests/unit/compute/test_compute.py
+++ b/nova/nova/tests/unit/compute/test_compute.py
@@ -180,7 +180,7 @@ class BaseTestCase(test.TestCase):
                     self.compute.driver, NODENAME)
         self.compute._resource_tracker_dict[NODENAME] = fake_rt
 
-        def fake_get_compute_nodes_in_db(context, use_slave=False):
+        def fake_get_compute_nodes_in_db(context, use_subordinate=False):
             fake_compute_nodes = [{'local_gb': 259,
                                    'vcpus_used': 0,
                                    'deleted': 0,
@@ -666,7 +666,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         time.time().AndReturn(20)
         time.time().AndReturn(21)
         objects.InstanceList.get_by_host(ctxt, 'fake-mini',
-                                         use_slave=True).AndReturn([])
+                                         use_subordinate=True).AndReturn([])
         self.compute.driver.get_all_bw_counters([]).AndRaise(
             NotImplementedError)
         self.mox.ReplayAll()
@@ -695,10 +695,10 @@ class ComputeVolumeTestCase(BaseTestCase):
         got_host_bdms = self.compute._get_host_volume_bdms('fake-context')
         mock_get_by_host.assert_called_once_with('fake-context',
                                                  self.compute.host,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         mock_get_by_inst.assert_called_once_with('fake-context',
                                                  'fake-instance-uuid',
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         self.assertEqual(expected_host_bdms, got_host_bdms)
 
     def test_poll_volume_usage_disabled(self):
@@ -719,7 +719,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.mox.StubOutWithMock(self.compute.driver, 'get_all_volume_usage')
         # Following methods are called.
         utils.last_completed_audit_period().AndReturn((0, 0))
-        self.compute._get_host_volume_bdms(ctxt, use_slave=True).AndReturn([])
+        self.compute._get_host_volume_bdms(ctxt, use_subordinate=True).AndReturn([])
         self.mox.ReplayAll()
 
         self.flags(volume_usage_poll_interval=10)
@@ -736,7 +736,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         # All the mocks are called
         utils.last_completed_audit_period().AndReturn((10, 20))
         self.compute._get_host_volume_bdms(ctxt,
-                                           use_slave=True).AndReturn([1, 2])
+                                           use_subordinate=True).AndReturn([1, 2])
         self.compute._update_volume_usage_cache(ctxt, [3, 4])
         self.mox.ReplayAll()
         self.flags(volume_usage_poll_interval=10)
@@ -766,7 +766,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.compute.driver.block_stats(instance, 'vdb').\
             AndReturn([1L, 30L, 1L, 20L, None])
         self.compute._get_host_volume_bdms(self.context,
-                                           use_slave=True).AndReturn(
+                                           use_subordinate=True).AndReturn(
                                                host_volume_bdms)
         self.compute.driver.get_all_volume_usage(
                 self.context, host_volume_bdms).AndReturn(
@@ -6005,9 +6005,9 @@ class ComputeTestCase(BaseTestCase):
         self.compute._shutdown_instance(ctxt, inst1, bdms, notify=False).\
                                         AndRaise(test.TestingException)
         objects.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst1.uuid, use_slave=True).AndReturn(bdms)
+                inst1.uuid, use_subordinate=True).AndReturn(bdms)
         objects.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst2.uuid, use_slave=True).AndReturn(bdms)
+                inst2.uuid, use_subordinate=True).AndReturn(bdms)
         self.compute._shutdown_instance(ctxt, inst2, bdms, notify=False).\
                                         AndReturn(None)
 
@@ -6111,7 +6111,7 @@ class ComputeTestCase(BaseTestCase):
         # does the right thing.
         db.instance_get_by_uuid(self.context, fake_inst['uuid'],
                                 columns_to_join=['system_metadata'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.compute.network_api.get_instance_nw_info(self.context,
                 mox.IsA(objects.Instance)).AndReturn(fake_nw_info)
@@ -6142,13 +6142,13 @@ class ComputeTestCase(BaseTestCase):
                 'get_nw_info': 0, 'expected_instance': None}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -6157,7 +6157,7 @@ class ComputeTestCase(BaseTestCase):
             return instance_map[instance_uuid]
 
         # NOTE(comstud): Override the stub in setUp()
-        def fake_get_instance_nw_info(context, instance, use_slave=False):
+        def fake_get_instance_nw_info(context, instance, use_subordinate=False):
             # Note that this exception gets caught in compute/manager
             # and is ignored.  However, the below increment of
             # 'get_nw_info' won't happen, and you'll get an assert
@@ -6245,7 +6245,7 @@ class ComputeTestCase(BaseTestCase):
 
         def fake_instance_get_all_by_filters(context, filters,
                                              expected_attrs=None,
-                                             use_slave=False):
+                                             use_subordinate=False):
             self.assertEqual(["system_metadata"], expected_attrs)
             return instances
 
@@ -6314,7 +6314,7 @@ class ComputeTestCase(BaseTestCase):
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for uuid 'noexist'
@@ -6325,7 +6325,7 @@ class ComputeTestCase(BaseTestCase):
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -6422,7 +6422,7 @@ class ComputeTestCase(BaseTestCase):
                                             sort_dir,
                                             marker=None,
                                             columns_to_join=[],
-                                            use_slave=True,
+                                            use_subordinate=True,
                                             limit=None)
             self.assertThat(conductor_instance_update.mock_calls,
                             testtools_matchers.HasLength(len(old_instances)))
@@ -6778,7 +6778,7 @@ class ComputeTestCase(BaseTestCase):
         objects.InstanceList.get_by_filters(
             ctxt, mox.IgnoreArg(),
             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True
+            use_subordinate=True
             ).AndReturn(instances)
 
         # The first instance delete fails.
@@ -6819,12 +6819,12 @@ class ComputeTestCase(BaseTestCase):
             hardware.InstanceInfo(state=power_state.RUNNING))
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.RUNNING,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.compute.driver.get_info(mox.IgnoreArg()).AndReturn(
             hardware.InstanceInfo(state=power_state.SHUTDOWN))
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.SHUTDOWN,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.mox.ReplayAll()
         self.compute._sync_power_states(ctxt)
 
@@ -10183,7 +10183,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-                aggregate=jsonutils.to_primitive(self.aggr), slave_info=None)
+                aggregate=jsonutils.to_primitive(self.aggr), subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -10197,36 +10197,36 @@ class ComputeAggrTestCase(BaseTestCase):
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="host",
-                slave_info=None)
+                subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-                slave_info="SLAVE_INFO",
+                subordinate_info="SLAVE_INFO",
                 aggregate=jsonutils.to_primitive(self.aggr))
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="the_host",
-                slave_info="SLAVE_INFO")
+                subordinate_info="SLAVE_INFO")
 
 
 class ComputePolicyTestCase(BaseTestCase):

--- a/nova/nova/tests/unit/compute/test_compute_api.py
+++ b/nova/nova/tests/unit/compute/test_compute_api.py
@@ -1103,7 +1103,7 @@ class _ComputeAPIUnitTestMixIn(object):
 
         db.block_device_mapping_get_all_by_instance(self.context,
                                                  inst.uuid,
-                                                 use_slave=False).AndReturn([])
+                                                 use_subordinate=False).AndReturn([])
         inst.save()
         self.compute_api._create_reservations(self.context,
                                               inst, inst.task_state,
@@ -1206,7 +1206,7 @@ class _ComputeAPIUnitTestMixIn(object):
         timeutils.set_time_override(delete_time)
 
         db.block_device_mapping_get_all_by_instance(
-            self.context, inst.uuid, use_slave=False).AndReturn([])
+            self.context, inst.uuid, use_subordinate=False).AndReturn([])
         inst.save().AndRaise(test.TestingException)
 
         self.mox.ReplayAll()
@@ -2005,7 +2005,7 @@ class _ComputeAPIUnitTestMixIn(object):
             'is_public': False
         }
 
-        def fake_get_all_by_instance(context, instance, use_slave=False):
+        def fake_get_all_by_instance(context, instance, use_subordinate=False):
             return copy.deepcopy(instance_bdms)
 
         def fake_image_create(context, image_meta, data=None):

--- a/nova/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/nova/tests/unit/compute/test_compute_mgr.py
@@ -321,7 +321,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             context.get_admin_context().AndReturn(fake_context)
             db.instance_get_all_by_host(
                     fake_context, our_host, columns_to_join=['info_cache'],
-                    use_slave=False
+                    use_subordinate=False
                     ).AndReturn(startup_instances)
             if defer_iptables_apply:
                 self.compute.driver.filter_defer_apply_on()
@@ -403,7 +403,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         context.get_admin_context().AndReturn(fake_context)
         db.instance_get_all_by_host(fake_context, our_host,
                                     columns_to_join=['info_cache'],
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn([])
         self.compute.init_virt_events()
 
@@ -938,7 +938,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                           inst in driver_instances]},
                 'created_at', 'desc', columns_to_join=None,
                 limit=None, marker=None,
-                use_slave=True).AndReturn(
+                use_subordinate=True).AndReturn(
                         driver_instances)
 
         self.mox.ReplayAll()
@@ -991,7 +991,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                 fake_context, filters,
                 'created_at', 'desc', columns_to_join=None,
                 limit=None, marker=None,
-                use_slave=True).AndReturn(all_instances)
+                use_subordinate=True).AndReturn(all_instances)
 
         self.mox.ReplayAll()
 
@@ -1032,7 +1032,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.compute._sync_power_states(mock.sentinel.context)
             mock_get.assert_called_with(mock.sentinel.context,
                                         self.compute.host, expected_attrs=[],
-                                        use_slave=True)
+                                        use_subordinate=True)
             mock_spawn.assert_called_once_with(mock.ANY, instance)
 
     def _get_sync_instance(self, power_state, vm_state, task_state=None,
@@ -1051,7 +1051,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_match(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.RUNNING)
@@ -1059,7 +1059,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_running_stopped(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
@@ -1070,7 +1070,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                            stop=True, force=False, shutdown_terminate=False):
         instance = self._get_sync_instance(
             power_state, vm_state, shutdown_terminate=shutdown_terminate)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.StubOutWithMock(self.compute.compute_api, 'stop')
         self.mox.StubOutWithMock(self.compute.compute_api, 'delete')
@@ -1141,7 +1141,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             mock_sync_power_state.assert_called_once_with(self.context,
                                                           db_instance,
                                                           power_state.NOSTATE,
-                                                          use_slave=True)
+                                                          use_subordinate=True)
 
     def test_run_pending_deletes(self):
         self.flags(instance_delete_interval=10)
@@ -1175,7 +1175,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
              'cleaned': False},
             expected_attrs=['info_cache', 'security_groups',
                             'system_metadata'],
-            use_slave=True).AndReturn([a, b, c])
+            use_subordinate=True).AndReturn([a, b, c])
 
         self.mox.StubOutWithMock(self.compute.driver, 'delete_instance_files')
         self.compute.driver.delete_instance_files(
@@ -2161,7 +2161,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                 'get_all_bw_counters', return_value=bw_counters):
             self.compute._poll_bandwidth_usage(self.context)
             get_by_uuid_mac.assert_called_once_with(self.context, 'fake-uuid',
-                    'fake-mac', start_period=0, use_slave=True)
+                    'fake-mac', start_period=0, use_subordinate=True)
             bw_usage_update.assert_called_once_with(self.context, 'fake-uuid',
                     'fake-mac', 0, 4, 6, 1, 2,
                     last_refreshed=timeutils.isotime(_time),
@@ -3100,7 +3100,7 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
             self.compute._get_instance_nw_info(self.context, instance)
         mock_get.assert_called_once_with(self.context, instance.uuid,
                                          expected_attrs=['system_metadata'],
-                                         use_slave=False)
+                                         use_subordinate=False)
 
     def test_build_networks_if_not_allocated(self):
         instance = fake_instance.fake_instance_obj(self.context,

--- a/nova/nova/tests/unit/compute/test_compute_utils.py
+++ b/nova/nova/tests/unit/compute/test_compute_utils.py
@@ -82,7 +82,7 @@ class ComputeValidateDeviceTestCase(test.NoDBTestCase):
         self.data = []
 
         self.stubs.Set(db, 'block_device_mapping_get_all_by_instance',
-                       lambda context, instance, use_slave=False: self.data)
+                       lambda context, instance, use_subordinate=False: self.data)
 
     def _update_flavor(self, flavor_info):
         self.flavor = {

--- a/nova/nova/tests/unit/compute/test_compute_xen.py
+++ b/nova/nova/tests/unit/compute/test_compute_xen.py
@@ -56,7 +56,7 @@ class ComputeXenTestCase(stubs.XenAPITestBaseNoDB):
 
         objects.InstanceList.get_by_host(ctxt,
                 self.compute.host, expected_attrs=[],
-                use_slave=True).AndReturn(instance_list)
+                use_subordinate=True).AndReturn(instance_list)
         self.compute.driver.get_num_instances().AndReturn(1)
         vm_utils.lookup(self.compute.driver._session, instance['name'],
                 False).AndReturn(None)

--- a/nova/nova/tests/unit/compute/test_multiple_nodes.py
+++ b/nova/nova/tests/unit/compute/test_multiple_nodes.py
@@ -72,7 +72,7 @@ class MultiNodeComputeTestCase(BaseTestCase):
         self.conductor = self.start_service('conductor',
                                             manager=CONF.conductor.manager)
 
-        def fake_get_compute_nodes_in_db(context, use_slave=False):
+        def fake_get_compute_nodes_in_db(context, use_subordinate=False):
             fake_compute_nodes = [{'local_gb': 259,
                                    'vcpus_used': 0,
                                    'deleted': 0,
@@ -139,7 +139,7 @@ class MultiNodeComputeTestCase(BaseTestCase):
                 context=ctx, hypervisor_hostname='B', id=3),
             ]
 
-        def fake_get_compute_nodes_in_db(context, use_slave=False):
+        def fake_get_compute_nodes_in_db(context, use_subordinate=False):
             return fake_compute_nodes
 
         def fake_compute_node_delete(context, compute_node_id):

--- a/nova/nova/tests/unit/compute/test_rpcapi.py
+++ b/nova/nova/tests/unit/compute/test_rpcapi.py
@@ -120,7 +120,7 @@ class ComputeRpcAPITestCase(test.TestCase):
     def test_add_aggregate_host(self):
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_add_fixed_ip_to_instance(self):
         self._test_compute_api('add_fixed_ip_to_instance', 'cast',
@@ -356,7 +356,7 @@ class ComputeRpcAPITestCase(test.TestCase):
     def test_remove_aggregate_host(self):
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_remove_fixed_ip_from_instance(self):
         self._test_compute_api('remove_fixed_ip_from_instance', 'cast',

--- a/nova/nova/tests/unit/conductor/test_conductor.py
+++ b/nova/nova/tests/unit/conductor/test_conductor.py
@@ -414,23 +414,23 @@ class ConductorTestCase(_BaseTestCase, test.TestCase):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=False)
+                                       columns_to_join=None, use_subordinate=False)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort',
                                                    None, False)
 
-    def test_instance_get_all_by_filters_use_slave(self):
+    def test_instance_get_all_by_filters_use_subordinate(self):
         filters = {'foo': 'bar'}
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=True)
+                                       columns_to_join=None, use_subordinate=True)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort',
                                                    columns_to_join=None,
-                                                   use_slave=True)
+                                                   use_subordinate=True)
 
     def test_instance_get_all_by_host(self):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_host')
@@ -1281,10 +1281,10 @@ class _BaseTaskTestCase(object):
                          {'host': 'host2', 'nodename': 'node2', 'limits': []}])
         db.instance_get_by_uuid(self.context, instances[0].uuid,
                 columns_to_join=['system_metadata'],
-                use_slave=False).AndReturn(
+                use_subordinate=False).AndReturn(
                         jsonutils.to_primitive(instances[0]))
         db.block_device_mapping_get_all_by_instance(self.context,
-                instances[0].uuid, use_slave=False).AndReturn([])
+                instances[0].uuid, use_subordinate=False).AndReturn([])
         self.conductor_manager.compute_rpcapi.build_and_run_instance(
                 self.context,
                 instance=mox.IgnoreArg(),
@@ -1306,10 +1306,10 @@ class _BaseTaskTestCase(object):
                 node='node1', limits=[])
         db.instance_get_by_uuid(self.context, instances[1].uuid,
                 columns_to_join=['system_metadata'],
-                use_slave=False).AndReturn(
+                use_subordinate=False).AndReturn(
                         jsonutils.to_primitive(instances[1]))
         db.block_device_mapping_get_all_by_instance(self.context,
-                instances[1].uuid, use_slave=False).AndReturn([])
+                instances[1].uuid, use_subordinate=False).AndReturn([])
         self.conductor_manager.compute_rpcapi.build_and_run_instance(
                 self.context,
                 instance=mox.IgnoreArg(),

--- a/nova/nova/tests/unit/db/test_db_api.py
+++ b/nova/nova/tests/unit/db/test_db_api.py
@@ -453,24 +453,24 @@ class NotDbApiTestCase(DbTestCase):
                           self.context, "")
 
     @mock.patch.object(sqlalchemy_api, 'get_session')
-    def test_model_query_use_slave_false(self, mock_get_session):
+    def test_model_query_use_subordinate_false(self, mock_get_session):
         sqlalchemy_api.model_query(self.context, models.Instance,
-                                   use_slave=False)
-        mock_get_session.assert_called_once_with(use_slave=False)
+                                   use_subordinate=False)
+        mock_get_session.assert_called_once_with(use_subordinate=False)
 
     @mock.patch.object(sqlalchemy_api, 'get_session')
-    def test_model_query_use_slave_no_slave_connection(self, mock_get_session):
-        self.flags(slave_connection='', group='database')
+    def test_model_query_use_subordinate_no_subordinate_connection(self, mock_get_session):
+        self.flags(subordinate_connection='', group='database')
         sqlalchemy_api.model_query(self.context, models.Instance,
-                                   use_slave=True)
-        mock_get_session.assert_called_once_with(use_slave=False)
+                                   use_subordinate=True)
+        mock_get_session.assert_called_once_with(use_subordinate=False)
 
     @mock.patch.object(sqlalchemy_api, 'get_session')
-    def test_model_query_use_slave_true(self, mock_get_session):
-        self.flags(slave_connection='foo://bar', group='database')
+    def test_model_query_use_subordinate_true(self, mock_get_session):
+        self.flags(subordinate_connection='foo://bar', group='database')
         sqlalchemy_api.model_query(self.context, models.Instance,
-                                   use_slave=True)
-        mock_get_session.assert_called_once_with(use_slave=True)
+                                   use_subordinate=True)
+        mock_get_session.assert_called_once_with(use_subordinate=True)
 
     @mock.patch.object(sqlalchemy_api, 'get_session')
     def test_model_query_lazy_session_default(self, mock_get_session):
@@ -989,10 +989,10 @@ class SqlAlchemyDbApiTestCase(DbTestCase):
         ctxt = context.get_admin_context()
         sqlalchemy_api.instance_get_all_by_filters(ctxt, {'foo': 'bar'},
             'sort_key', 'sort_dir', limit=100, marker='uuid',
-            columns_to_join='columns', use_slave=True)
+            columns_to_join='columns', use_subordinate=True)
         mock_get_all_filters_sort.assert_called_once_with(ctxt, {'foo': 'bar'},
             limit=100, marker='uuid', columns_to_join='columns',
-            use_slave=True, sort_keys=['sort_key'], sort_dirs=['sort_dir'])
+            use_subordinate=True, sort_keys=['sort_key'], sort_dirs=['sort_dir'])
 
 
 class ProcessSortParamTestCase(test.TestCase):

--- a/nova/nova/tests/unit/network/test_api.py
+++ b/nova/nova/tests/unit/network/test_api.py
@@ -125,7 +125,7 @@ class ApiTestCase(test.TestCase):
         self.assertEqual(123, vifs[0].network_id)
         self.assertEqual(str(mock.sentinel.network_uuid), vifs[0].net_uuid)
         mock_get_by_instance.assert_called_once_with(
-            self.context, str(mock.sentinel.inst_uuid), use_slave=False)
+            self.context, str(mock.sentinel.inst_uuid), use_subordinate=False)
         mock_get_by_id.assert_called_once_with(self.context, 123,
                                                project_only='allow_none')
 
@@ -184,7 +184,7 @@ class ApiTestCase(test.TestCase):
 
         def fake_instance_get_by_uuid(context, instance_uuid,
                                       columns_to_join=None,
-                                      use_slave=None):
+                                      use_subordinate=None):
             return fake_instance.fake_db_instance(uuid=instance_uuid)
 
         self.stubs.Set(self.network_api.db, 'instance_get_by_uuid',

--- a/nova/nova/tests/unit/network/test_linux_net.py
+++ b/nova/nova/tests/unit/network/test_linux_net.py
@@ -392,7 +392,7 @@ class LinuxNetworkTestCase(test.NoDBTestCase):
         self.context = context.RequestContext('testuser', 'testproject',
                                               is_admin=True)
 
-        def get_vifs(_context, instance_uuid, use_slave):
+        def get_vifs(_context, instance_uuid, use_subordinate):
             return [vif for vif in vifs if vif['instance_uuid'] ==
                         instance_uuid]
 

--- a/nova/nova/tests/unit/network/test_manager.py
+++ b/nova/nova/tests/unit/network/test_manager.py
@@ -482,7 +482,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -535,7 +535,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -632,7 +632,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -931,7 +931,7 @@ class VlanNetworkTestCase(test.TestCase):
         db.virtual_interface_get_by_instance_and_network(mox.IgnoreArg(),
                 mox.IgnoreArg(), mox.IgnoreArg()).AndReturn(vifs[0])
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -979,7 +979,7 @@ class VlanNetworkTestCase(test.TestCase):
         db.virtual_interface_get_by_instance_and_network(mox.IgnoreArg(),
                 mox.IgnoreArg(), mox.IgnoreArg()).AndReturn(vifs[0])
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -1660,7 +1660,7 @@ class VlanNetworkTestCase(test.TestCase):
                        ).AndReturn(dict(test_network.fake_network,
                                         **networks[0]))
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,

--- a/nova/nova/tests/unit/objects/test_instance.py
+++ b/nova/nova/tests/unit/objects/test_instance.py
@@ -109,7 +109,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, 'uuid',
                                 columns_to_join=[],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, 'uuid',
@@ -142,7 +142,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(
             self.context, 'uuid',
             columns_to_join=exp_cols,
-            use_slave=False
+            use_subordinate=False
             ).AndReturn(fake_instance)
         fake_faults = test_instance_fault.fake_faults
         db.instance_fault_get_by_instance_uuids(
@@ -174,13 +174,13 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         fake_inst2 = dict(self.fake_instance,
                           system_metadata=[{'key': 'foo', 'value': 'bar'}])
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['system_metadata'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst2)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -205,7 +205,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, 'fake-uuid',
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_instance)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, 'fake-uuid')
@@ -223,13 +223,13 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(dict(self.fake_instance,
                                                  host='orig-host'))
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(dict(self.fake_instance,
                                                  host='new-host'))
         self.mox.StubOutWithMock(instance_info_cache.InstanceInfoCache,
@@ -251,7 +251,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(instance.Instance, 'get_by_uuid')
         instance.Instance.get_by_uuid(self.context, uuid=inst.uuid,
                                       expected_attrs=['metadata'],
-                                      use_slave=False
+                                      use_subordinate=False
                                       ).AndReturn(inst_copy)
         self.mox.ReplayAll()
         self.assertRaises(exception.OrphanedObjectError, inst.refresh)
@@ -298,7 +298,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(old_ref)
         db.instance_update_and_get_original(
                 self.context, fake_uuid, expected_updates,
@@ -378,7 +378,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(old_ref)
         db.instance_update_and_get_original(
                 self.context, fake_uuid, expected_updates, update_cells=False,
@@ -391,7 +391,7 @@ class _TestInstanceObject(object):
         self.mox.ReplayAll()
 
         inst = instance.Instance.get_by_uuid(self.context, old_ref['uuid'],
-                                             use_slave=False)
+                                             use_subordinate=False)
         self.assertEqual('hello', inst.display_name)
         inst.display_name = 'goodbye'
         inst.save()
@@ -455,7 +455,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -469,7 +469,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -483,7 +483,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -507,7 +507,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         db.instance_info_cache_update(self.context, fake_uuid,
                                       {'network_info': nwinfo2_json})
@@ -524,7 +524,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -550,7 +550,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         db.security_group_update(self.context, 1, {'description': 'changed'}
                                  ).AndReturn(fake_inst['security_groups'][0])
@@ -575,7 +575,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -587,7 +587,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['pci_devices'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -637,7 +637,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['pci_devices'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -655,7 +655,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_fault_get_by_instance_uuids')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=[],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         db.instance_fault_get_by_instance_uuids(
             self.context, [fake_uuid]).AndReturn({fake_uuid: fake_faults})
@@ -1047,11 +1047,11 @@ class _TestInstanceListObject(object):
         db.instance_get_all_by_filters(self.context, {'foo': 'bar'}, 'uuid',
                                        'asc', limit=None, marker=None,
                                        columns_to_join=['metadata'],
-                                       use_slave=False).AndReturn(fakes)
+                                       use_subordinate=False).AndReturn(fakes)
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1064,13 +1064,13 @@ class _TestInstanceListObject(object):
         db.instance_get_all_by_filters_sort(self.context, {'foo': 'bar'},
                                             limit=None, marker=None,
                                             columns_to_join=['metadata'],
-                                            use_slave=False,
+                                            use_subordinate=False,
                                             sort_keys=['uuid'],
                                             sort_dirs=['asc']).AndReturn(fakes)
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, expected_attrs=['metadata'],
-            use_slave=False, sort_keys=['uuid'], sort_dirs=['asc'])
+            use_subordinate=False, sort_keys=['uuid'], sort_dirs=['asc'])
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1086,10 +1086,10 @@ class _TestInstanceListObject(object):
         # Single sort key/direction is set, call non-sorted DB function
         instance.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, sort_key='key', sort_dir='dir',
-            limit=100, marker='uuid', use_slave=True)
+            limit=100, marker='uuid', use_subordinate=True)
         mock_get_by_filters.assert_called_once_with(
             self.context, {'foo': 'bar'}, 'key', 'dir', limit=100,
-            marker='uuid', columns_to_join=None, use_slave=True)
+            marker='uuid', columns_to_join=None, use_subordinate=True)
         self.assertEqual(0, mock_get_by_filters_sort.call_count)
 
     @mock.patch.object(db, 'instance_get_all_by_filters_sort')
@@ -1101,11 +1101,11 @@ class _TestInstanceListObject(object):
         # Multiple sort keys/directions are set, call sorted DB function
         instance.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, limit=100, marker='uuid',
-            use_slave=True, sort_keys=['key1', 'key2'],
+            use_subordinate=True, sort_keys=['key1', 'key2'],
             sort_dirs=['dir1', 'dir2'])
         mock_get_by_filters_sort.assert_called_once_with(
             self.context, {'foo': 'bar'}, limit=100,
-            marker='uuid', columns_to_join=None, use_slave=True,
+            marker='uuid', columns_to_join=None, use_subordinate=True,
             sort_keys=['key1', 'key2'], sort_dirs=['dir1', 'dir2'])
         self.assertEqual(0, mock_get_by_filters.call_count)
 
@@ -1119,12 +1119,12 @@ class _TestInstanceListObject(object):
                                        {'deleted': True, 'cleaned': False},
                                        'uuid', 'asc', limit=None, marker=None,
                                        columns_to_join=['metadata'],
-                                       use_slave=False).AndReturn(
+                                       use_subordinate=False).AndReturn(
                                            [fakes[1]])
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_filters(
             self.context, {'deleted': True, 'cleaned': False}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         self.assertEqual(1, len(inst_list))
         self.assertIsInstance(inst_list.objects[0], instance.Instance)
@@ -1137,7 +1137,7 @@ class _TestInstanceListObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_host')
         db.instance_get_all_by_host(self.context, 'foo',
                                     columns_to_join=None,
-                                    use_slave=False).AndReturn(fakes)
+                                    use_subordinate=False).AndReturn(fakes)
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_host(self.context, 'foo')
         for i in range(0, len(fakes)):
@@ -1228,7 +1228,7 @@ class _TestInstanceListObject(object):
         self.mox.StubOutWithMock(db, 'instance_fault_get_by_instance_uuids')
         db.instance_get_all_by_host(self.context, 'host',
                                     columns_to_join=[],
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn(fake_insts)
         db.instance_fault_get_by_instance_uuids(
             self.context, [x['uuid'] for x in fake_insts]
@@ -1236,7 +1236,7 @@ class _TestInstanceListObject(object):
         self.mox.ReplayAll()
         instances = instance.InstanceList.get_by_host(self.context, 'host',
                                                       expected_attrs=['fault'],
-                                                      use_slave=False)
+                                                      use_subordinate=False)
         self.assertEqual(2, len(instances))
         self.assertEqual(fake_faults['fake-uuid'][0],
                          dict(instances[0].fault.iteritems()))

--- a/nova/nova/tests/unit/objects/test_migration.py
+++ b/nova/nova/tests/unit/objects/test_migration.py
@@ -117,7 +117,7 @@ class _TestMigrationObject(object):
         db.instance_get_by_uuid(ctxt, fake_migration['instance_uuid'],
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         mig = migration.Migration._from_db_object(ctxt,
                                                   migration.Migration(),
@@ -134,11 +134,11 @@ class _TestMigrationObject(object):
             db, 'migration_get_unconfirmed_by_dest_compute')
         db.migration_get_unconfirmed_by_dest_compute(
             ctxt, 'window', 'foo',
-            use_slave=False).AndReturn(db_migrations)
+            use_subordinate=False).AndReturn(db_migrations)
         self.mox.ReplayAll()
         migrations = (
             migration.MigrationList.get_unconfirmed_by_dest_compute(
-                ctxt, 'window', 'foo', use_slave=False))
+                ctxt, 'window', 'foo', use_subordinate=False))
         self.assertEqual(2, len(migrations))
         for index, db_migration in enumerate(db_migrations):
             self.compare_obj(migrations[index], db_migration)

--- a/nova/nova/tests/unit/test_metadata.py
+++ b/nova/nova/tests/unit/test_metadata.py
@@ -204,7 +204,7 @@ class MetadataTestCase(test.TestCase):
                          'default_ephemeral_device': None,
                          'default_swap_device': None})
 
-        def fake_bdm_get(ctxt, uuid, use_slave=False):
+        def fake_bdm_get(ctxt, uuid, use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                     {'volume_id': 87654321,
                      'snapshot_id': None,

--- a/nova/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/nova/tests/unit/virt/libvirt/test_driver.py
@@ -7732,7 +7732,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
         db.instance_get_by_uuid(mox.IgnoreArg(), mox.IgnoreArg(),
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(instance)
         self.mox.StubOutWithMock(driver, "block_device_info_get_mapping")
         driver.block_device_info_get_mapping(vol

--- a/nova/nova/tests/unit/virt/xenapi/test_xenapi.py
+++ b/nova/nova/tests/unit/virt/xenapi/test_xenapi.py
@@ -1456,7 +1456,7 @@ iface eth0 inet6 static
         fake_inst2 = fake_instance.fake_db_instance(id=456)
         db.instance_get_all_by_host(self.context, fake_inst['host'],
                                     columns_to_join=None,
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn([fake_inst, fake_inst2])
         self.mox.ReplayAll()
         expected_name = CONF.instance_name_template % fake_inst['id']
@@ -1473,7 +1473,7 @@ iface eth0 inet6 static
         self.stubs.Set(db, "aggregate_get_by_host",
                        fake_aggregate_get_by_host)
 
-        self.stubs.Set(self.conn._session, "is_slave", True)
+        self.stubs.Set(self.conn._session, "is_subordinate", True)
 
         self.assertRaises(test.TestingException,
                 self.conn._session._get_host_uuid)
@@ -2976,7 +2976,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                   pool_states.POOL_FLAG: 'XenAPI'}}
         self.aggr = db.aggregate_create(self.context, values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               'availability_zone': 'fake_zone',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
@@ -2986,18 +2986,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
 
         calls = []
 
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_add_to_aggregate)
         self.stubs.Set(self.conn._pool,
                        "add_to_aggregate",
                        pool_add_to_aggregate)
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_add_to_aggregate, calls)
 
@@ -3006,18 +3006,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         calls = []
 
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_remove_from_aggregate)
         self.stubs.Set(self.conn._pool,
                        "remove_from_aggregate",
                        pool_remove_from_aggregate)
 
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_remove_from_aggregate, calls)
 
@@ -3033,11 +3033,11 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result['metadetails']))
 
-    def test_join_slave(self):
-        # Ensure join_slave gets called when the request gets to master.
-        def fake_join_slave(id, compute_uuid, host, url, user, password):
-            fake_join_slave.called = True
-        self.stubs.Set(self.conn._pool, "_join_slave", fake_join_slave)
+    def test_join_subordinate(self):
+        # Ensure join_subordinate gets called when the request gets to main.
+        def fake_join_subordinate(id, compute_uuid, host, url, user, password):
+            fake_join_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_join_subordinate", fake_join_subordinate)
 
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
@@ -3047,7 +3047,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(fake_join_slave.called)
+        self.assertTrue(fake_join_subordinate.called)
 
     def test_add_to_aggregate_first_host(self):
         def fake_pool_set_name_label(self, session, pool_ref, name):
@@ -3087,19 +3087,19 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    def test_remove_slave(self):
-        # Ensure eject slave gets called.
-        def fake_eject_slave(id, compute_uuid, host_uuid):
-            fake_eject_slave.called = True
-        self.stubs.Set(self.conn._pool, "_eject_slave", fake_eject_slave)
+    def test_remove_subordinate(self):
+        # Ensure eject subordinate gets called.
+        def fake_eject_subordinate(id, compute_uuid, host_uuid):
+            fake_eject_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_eject_subordinate", fake_eject_subordinate)
 
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(fake_eject_slave.called)
+        self.assertTrue(fake_eject_subordinate.called)
 
-    def test_remove_master_solo(self):
+    def test_remove_main_solo(self):
         # Ensure metadata are cleared after removal.
         def fake_clear_pool(id):
             fake_clear_pool.called = True
@@ -3114,8 +3114,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result['metadetails']))
 
-    def test_remote_master_non_empty_pool(self):
-        # Ensure AggregateError is raised if removing the master.
+    def test_remote_main_non_empty_pool(self):
+        # Ensure AggregateError is raised if removing the main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -3225,7 +3225,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.compute.add_aggregate_host,
                           self.context, host="fake_host",
                           aggregate=jsonutils.to_primitive(self.aggr),
-                          slave_info=None)
+                          subordinate_info=None)
         excepted = db.aggregate_get(self.context, self.aggr['id'])
         self.assertEqual(excepted['metadetails'][pool_states.KEY],
                 pool_states.ERROR)
@@ -3237,16 +3237,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, aggregate_id, host_param,
-                              host, slave_info):
+                              host, subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, aggregate_id,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
 
 class StubDependencies(object):
@@ -3261,10 +3261,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -3278,32 +3278,32 @@ class HypervisorPoolTestCase(test.NoDBTestCase):
         'id': 98,
         'hosts': [],
         'metadata': {
-            'master_compute': 'master',
+            'main_compute': 'main',
             pool_states.POOL_FLAG: {},
             pool_states.KEY: {}
             }
         }
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.add_to_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
+            (subordinate.compute_rpcapi.add_aggregate_host,
             "CONTEXT", jsonutils.to_primitive(self.fake_aggregate),
-            "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.remove_from_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.remove_from_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-            "CONTEXT", 98, "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+            "CONTEXT", 98, "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.NoDBTestCase):

--- a/nova/nova/virt/xenapi/client/session.py
+++ b/nova/nova/virt/xenapi/client/session.py
@@ -83,7 +83,7 @@ class XenAPISession(object):
         import XenAPI
         self.XenAPI = XenAPI
         self._sessions = queue.Queue()
-        self.is_slave = False
+        self.is_subordinate = False
         exception = self.XenAPI.Failure(_("Unable to log in to XenAPI "
                                           "(is the Dom0 disk full?)"))
         url = self._create_first_session(url, user, pw, exception)
@@ -114,14 +114,14 @@ class XenAPISession(object):
                 session.login_with_password(user, pw,
                                             self.nova_version, 'OpenStack')
         except self.XenAPI.Failure as e:
-            # if user and pw of the master are different, we're doomed!
+            # if user and pw of the main are different, we're doomed!
             if e.details[0] == 'HOST_IS_SLAVE':
-                master = e.details[1]
-                url = pool.swap_xapi_host(url, master)
+                main = e.details[1]
+                url = pool.swap_xapi_host(url, main)
                 session = self.XenAPI.Session(url)
                 session.login_with_password(user, pw,
                                             self.nova_version, 'OpenStack')
-                self.is_slave = True
+                self.is_subordinate = True
             else:
                 raise
         self._sessions.put(session)
@@ -136,7 +136,7 @@ class XenAPISession(object):
             self._sessions.put(session)
 
     def _get_host_uuid(self):
-        if self.is_slave:
+        if self.is_subordinate:
             aggr = objects.AggregateList.get_by_host(
                 context.get_admin_context(),
                 CONF.host, key=pool_states.POOL_FLAG)[0]

--- a/nova/nova/virt/xenapi/fake.py
+++ b/nova/nova/virt/xenapi/fake.py
@@ -106,7 +106,7 @@ def create_host(name_label, hostname='fake_name', address='fake_addr'):
     # Create a pool if we don't have one already
     if len(_db_content['pool']) == 0:
         pool_ref = _create_pool('')
-        _db_content['pool'][pool_ref]['master'] = host_ref
+        _db_content['pool'][pool_ref]['main'] = host_ref
         _db_content['pool'][pool_ref]['default-SR'] = host_default_sr_ref
         _db_content['pool'][pool_ref]['suspend-image-SR'] = host_default_sr_ref
 
@@ -872,7 +872,7 @@ class SessionBase(object):
             return self._session
         elif name == 'xenapi':
             return _Dispatcher(self.xenapi_request, None)
-        elif name.startswith('login') or name.startswith('slave_local'):
+        elif name.startswith('login') or name.startswith('subordinate_local'):
             return lambda *params: self._login(name, params)
         elif name.startswith('Async'):
             return lambda *params: self._async(name, params)

--- a/nova/nova/virt/xenapi/pool.py
+++ b/nova/nova/virt/xenapi/pool.py
@@ -66,7 +66,7 @@ class ResourcePool(object):
                               'state during operation on %(host)s'),
                           {'aggregate_id': aggregate['id'], 'host': host})
 
-    def add_to_aggregate(self, context, aggregate, host, slave_info=None):
+    def add_to_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Add a compute host to an aggregate."""
         if not pool_states.is_hv_pool(aggregate['metadata']):
             return
@@ -83,38 +83,38 @@ class ResourcePool(object):
         if (aggregate['metadata'][pool_states.KEY] == pool_states.CREATED):
             aggregate.update_metadata({pool_states.KEY: pool_states.CHANGING})
         if len(aggregate['hosts']) == 1:
-            # this is the first host of the pool -> make it master
+            # this is the first host of the pool -> make it main
             self._init_pool(aggregate['id'], aggregate['name'])
-            # save metadata so that we can find the master again
-            metadata = {'master_compute': host,
+            # save metadata so that we can find the main again
+            metadata = {'main_compute': host,
                         host: self._host_uuid,
                         pool_states.KEY: pool_states.ACTIVE}
             aggregate.update_metadata(metadata)
         else:
             # the pool is already up and running, we need to figure out
             # whether we can serve the request from this host or not.
-            master_compute = aggregate['metadata']['master_compute']
-            if master_compute == CONF.host and master_compute != host:
-                # this is the master ->  do a pool-join
-                # To this aim, nova compute on the slave has to go down.
+            main_compute = aggregate['metadata']['main_compute']
+            if main_compute == CONF.host and main_compute != host:
+                # this is the main ->  do a pool-join
+                # To this aim, nova compute on the subordinate has to go down.
                 # NOTE: it is assumed that ONLY nova compute is running now
-                self._join_slave(aggregate['id'], host,
-                                 slave_info.get('compute_uuid'),
-                                 slave_info.get('url'), slave_info.get('user'),
-                                 slave_info.get('passwd'))
-                metadata = {host: slave_info.get('xenhost_uuid'), }
+                self._join_subordinate(aggregate['id'], host,
+                                 subordinate_info.get('compute_uuid'),
+                                 subordinate_info.get('url'), subordinate_info.get('user'),
+                                 subordinate_info.get('passwd'))
+                metadata = {host: subordinate_info.get('xenhost_uuid'), }
                 aggregate.update_metadata(metadata)
-            elif master_compute and master_compute != host:
-                # send rpc cast to master, asking to add the following
+            elif main_compute and main_compute != host:
+                # send rpc cast to main, asking to add the following
                 # host with specified credentials.
-                slave_info = self._create_slave_info()
+                subordinate_info = self._create_subordinate_info()
 
                 self.compute_rpcapi.add_aggregate_host(
-                    context, aggregate, host, master_compute, slave_info)
+                    context, aggregate, host, main_compute, subordinate_info)
 
-    def remove_from_aggregate(self, context, aggregate, host, slave_info=None):
+    def remove_from_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Remove a compute host from an aggregate."""
-        slave_info = slave_info or dict()
+        subordinate_info = subordinate_info or dict()
         if not pool_states.is_hv_pool(aggregate['metadata']):
             return
 
@@ -126,19 +126,19 @@ class ResourcePool(object):
                     aggregate_id=aggregate['id'],
                     reason=invalid[aggregate['metadata'][pool_states.KEY]])
 
-        master_compute = aggregate['metadata']['master_compute']
-        if master_compute == CONF.host and master_compute != host:
-            # this is the master -> instruct it to eject a host from the pool
+        main_compute = aggregate['metadata']['main_compute']
+        if main_compute == CONF.host and main_compute != host:
+            # this is the main -> instruct it to eject a host from the pool
             host_uuid = aggregate['metadata'][host]
-            self._eject_slave(aggregate['id'],
-                              slave_info.get('compute_uuid'), host_uuid)
+            self._eject_subordinate(aggregate['id'],
+                              subordinate_info.get('compute_uuid'), host_uuid)
             aggregate.update_metadata({host: None})
-        elif master_compute == host:
-            # Remove master from its own pool -> destroy pool only if the
-            # master is on its own, otherwise raise fault. Destroying a
-            # pool made only by master is fictional
+        elif main_compute == host:
+            # Remove main from its own pool -> destroy pool only if the
+            # main is on its own, otherwise raise fault. Destroying a
+            # pool made only by main is fictional
             if len(aggregate['hosts']) > 1:
-                # NOTE: this could be avoided by doing a master
+                # NOTE: this could be avoided by doing a main
                 # re-election, but this is simpler for now.
                 raise exception.InvalidAggregateActionDelete(
                                     aggregate_id=aggregate['id'],
@@ -146,32 +146,32 @@ class ResourcePool(object):
                                              'from the pool; pool not empty')
                                              % host)
             self._clear_pool(aggregate['id'])
-            aggregate.update_metadata({'master_compute': None, host: None})
-        elif master_compute and master_compute != host:
-            # A master exists -> forward pool-eject request to master
-            slave_info = self._create_slave_info()
+            aggregate.update_metadata({'main_compute': None, host: None})
+        elif main_compute and main_compute != host:
+            # A main exists -> forward pool-eject request to main
+            subordinate_info = self._create_subordinate_info()
 
             self.compute_rpcapi.remove_aggregate_host(
-                context, aggregate['id'], host, master_compute, slave_info)
+                context, aggregate['id'], host, main_compute, subordinate_info)
         else:
             # this shouldn't have happened
             raise exception.AggregateError(aggregate_id=aggregate['id'],
                                            action='remove_from_aggregate',
                                            reason=_('Unable to eject %s '
-                                           'from the pool; No master found')
+                                           'from the pool; No main found')
                                            % host)
 
-    def _join_slave(self, aggregate_id, host, compute_uuid, url, user, passwd):
-        """Joins a slave into a XenServer resource pool."""
+    def _join_subordinate(self, aggregate_id, host, compute_uuid, url, user, passwd):
+        """Joins a subordinate into a XenServer resource pool."""
         try:
             args = {'compute_uuid': compute_uuid,
                     'url': url,
                     'user': user,
                     'password': passwd,
                     'force': jsonutils.dumps(CONF.xenserver.use_join_force),
-                    'master_addr': self._host_addr,
-                    'master_user': CONF.xenserver.connection_username,
-                    'master_pass': CONF.xenserver.connection_password, }
+                    'main_addr': self._host_addr,
+                    'main_user': CONF.xenserver.connection_username,
+                    'main_pass': CONF.xenserver.connection_password, }
             self._session.call_plugin('xenhost', 'host_join', args)
         except self._session.XenAPI.Failure as e:
             LOG.error(_LE("Pool-Join failed: %s"), e)
@@ -180,8 +180,8 @@ class ResourcePool(object):
                                            reason=_('Unable to join %s '
                                                   'in the pool') % host)
 
-    def _eject_slave(self, aggregate_id, compute_uuid, host_uuid):
-        """Eject a slave from a XenServer resource pool."""
+    def _eject_subordinate(self, aggregate_id, compute_uuid, host_uuid):
+        """Eject a subordinate from a XenServer resource pool."""
         try:
             # shutdown nova-compute; if there are other VMs running, e.g.
             # guest instances, the eject will fail. That's a precaution
@@ -220,7 +220,7 @@ class ResourcePool(object):
                                            action='remove_from_aggregate',
                                            reason=six.text_type(e.details))
 
-    def _create_slave_info(self):
+    def _create_subordinate_info(self):
         """XenServer specific info needed to join the hypervisor pool."""
         # replace the address from the xenapi connection url
         # because this might be 169.254.0.1, i.e. xenapi

--- a/nova/nova/virt/xenapi/pool_states.py
+++ b/nova/nova/virt/xenapi/pool_states.py
@@ -25,7 +25,7 @@ cases.
 A 'created' pool becomes 'changing' during the first request of
 adding a host. During a 'changing' status no other requests will be accepted;
 this is to allow the hypervisor layer to instantiate the underlying pool
-without any potential race condition that may incur in master/slave-based
+without any potential race condition that may incur in main/subordinate-based
 configurations. The pool goes into the 'active' state when the underlying
 pool has been correctly instantiated.
 All other operations (e.g. add/remove hosts) that succeed will keep the

--- a/nova/tools/db/schema_diff.py
+++ b/nova/tools/db/schema_diff.py
@@ -33,12 +33,12 @@ Run like:
     MYSQL:
 
     ./tools/db/schema_diff.py mysql://root@localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 
     POSTGRESQL:
 
     ./tools/db/schema_diff.py postgresql://localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 """
 
 from __future__ import print_function
@@ -228,12 +228,12 @@ def parse_options():
     try:
         orig_branch, orig_version = sys.argv[2].split(':')
     except IndexError:
-        usage('original branch and version required (e.g. master:82)')
+        usage('original branch and version required (e.g. main:82)')
 
     try:
         new_branch, new_version = sys.argv[3].split(':')
     except IndexError:
-        usage('new branch and version required (e.g. master:82)')
+        usage('new branch and version required (e.g. main:82)')
 
     return db_url, orig_branch, orig_version, new_branch, new_version
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.